### PR TITLE
Change BinaryInputPin to use notifiable concept

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Warning options for the compiler
 string(
   APPEND _warning_opts
-  "$<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wall;-Wextra;-Weffc++;-Werror;-Wno-unused-parameter;>"
+  "$<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wall;-Wextra;-Weffc++;-Werror;>"
   "$<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wthread-safety;-Wpedantic;>"
   "$<$<CXX_COMPILER_ID:GNU>:-pedantic;-pedantic-errors;>"
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Warning options for the compiler
 string(
   APPEND _warning_opts
-  "$<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wall;-Wextra;-Weffc++;-Werror;>"
+  "$<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wall;-Wextra;-Weffc++;-Werror;-Wno-unused-parameter;>"
   "$<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wthread-safety;-Wpedantic;>"
   "$<$<CXX_COMPILER_ID:GNU>:-pedantic;-pedantic-errors;>"
   )

--- a/include/binaryinputpin.hpp
+++ b/include/binaryinputpin.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <set>
+#include <vector>
 #include <memory>
 
 #include "notifiable.hpp"
@@ -30,10 +30,14 @@ namespace Lineside {
     
   private:
     struct Listener {
+      Listener(int reqSrcId, std::weak_ptr<Notifiable<bool>> l) :
+	requestedSourceId(reqSrcId),
+	listener(l) {}
+      
       int requestedSourceId;
       std::weak_ptr<Notifiable<bool>> listener;
     };
     
-    std::set<Listener> listeners;
+    std::vector<Listener> listeners;
   };
 }

--- a/include/binaryinputpin.hpp
+++ b/include/binaryinputpin.hpp
@@ -31,7 +31,7 @@ namespace Lineside {
   private:
     struct Listener {
       int requestedSourceId;
-      std::weak_ptr<Notifiable<bool>> listener
+      std::weak_ptr<Notifiable<bool>> listener;
     };
     
     std::set<Listener> listeners;

--- a/include/notifiable.hpp
+++ b/include/notifiable.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace Lineside {
+  //! Abstraction for something which can receive notifications
+  template<typename NotificationType>
+  class Notifiable {
+  public:
+    //! Method to be called when some event occurs
+    virtual void Notify(const int sourceId, const NotificationType notification) = 0;
+  };
+}

--- a/include/notifiable.hpp
+++ b/include/notifiable.hpp
@@ -5,6 +5,8 @@ namespace Lineside {
   template<typename NotificationType>
   class Notifiable {
   public:
+    virtual ~Notifiable() {}
+    
     //! Method to be called when some event occurs
     virtual void Notify(const int sourceId, const NotificationType notification) = 0;
   };

--- a/src/binaryinputpin.cpp
+++ b/src/binaryinputpin.cpp
@@ -3,10 +3,18 @@
 namespace Lineside {
   void BinaryInputPin::RegisterListener(const int requestedSourceId,
 					std::weak_ptr<Notifiable<bool>> listener) {
-    throw std::logic_error(__FUNCTION__);
+    this->listeners.push_back(Listener(requestedSourceId, listener));
   }
 
   void BinaryInputPin::NotifyUpdate() {
-    throw std::logic_error(__FUNCTION__);
+    for( auto it=this->listeners.begin(); it!=this->listeners.end(); ++it) {
+      // Get a shared_ptr to the listener
+      auto l = it->listener.lock();
+
+      // Guard against expired pointers
+      if( l.use_count() > 0 ) {
+	l->Notify(it->requestedSourceId, this->Get());
+      }
+    }
   }
 }

--- a/src/binaryinputpin.cpp
+++ b/src/binaryinputpin.cpp
@@ -1,17 +1,12 @@
 #include "binaryinputpin.hpp"
 
 namespace Lineside {
-  bool BinaryInputPin::Wait() {
-    std::atomic<bool> last;
-    std::unique_lock<std::mutex> lck(this->mtx);
-    last = this->Get();
-    // Specify predicate function to guard against spurious wakeups
-    this->cv.wait( lck, [this,&last](){ return last != this->Get(); } );
-    return this->Get();
+  void BinaryInputPin::RegisterListener(const int requestedSourceId,
+					std::weak_ptr<Notifiable<bool>> listener) {
+    throw std::logic_error(__FUNCTION__);
   }
 
-  void BinaryInputPin::NotifyOneUpdate() {
-    std::lock_guard<std::mutex> lg(this->mtx);
-    this->cv.notify_one();
+  void BinaryInputPin::NotifyUpdate() {
+    throw std::logic_error(__FUNCTION__);
   }
 }

--- a/tst/mockbiptests.cpp
+++ b/tst/mockbiptests.cpp
@@ -94,4 +94,20 @@ BOOST_AUTO_TEST_CASE(NotifyTwoTargets)
   BOOST_CHECK_EQUAL( nt2->lastNotification, false );
 }
 
+BOOST_AUTO_TEST_CASE(ExpiredTargetHarmless)
+{
+  MockBIP mb;
+
+  {
+    const int srcId = 10;
+    std::shared_ptr<NotifyTarget> nt(new NotifyTarget);
+
+    mb.RegisterListener( srcId, nt );
+    // nt Goes out of scope and we only took a weak_ptr
+  }
+
+  // Still should be OK
+  BOOST_CHECK_NO_THROW(mb.Set(true));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/mocks/mockbip.cpp
+++ b/tst/mocks/mockbip.cpp
@@ -6,5 +6,5 @@ bool MockBIP::Get() const {
 
 void MockBIP::Set(const bool level) {
   this->state = level;
-  this->NotifyOneUpdate();
+  this->NotifyUpdate();
 }


### PR DESCRIPTION
Having different classes responsible for thread management seems like a bad idea

Introduce the concept of a `Notifiable` class and use this in the `BinaryInputPin`