### PR TITLE
Infrastructure for permanent way items

### DIFF
--- a/include/binaryinputpin.hpp
+++ b/include/binaryinputpin.hpp
@@ -22,7 +22,7 @@ namespace Lineside {
     //! Reads the current state of the pin
     virtual bool Get() const = 0;
 
-    void RegisterListener(const int requestedSourceId,
+    void RegisterListener(const unsigned int requestedSourceId,
 			  std::weak_ptr<Notifiable<bool>> listener);
     
   protected:

--- a/include/linesideexceptions.hpp
+++ b/include/linesideexceptions.hpp
@@ -3,11 +3,38 @@
 #include <stdexcept>
 #include <sstream>
 
+#include "itemid.hpp"
+
 namespace Lineside {
   //! Base class for all exceptions from this library
   class LinesideException : public std::runtime_error {
   public:
     LinesideException(const std::string& what_arg ) : runtime_error(what_arg) {}
+  };
+
+  // ========================================
+
+  //! Exception for mismatched ItemIds
+  class ItemIdMismatchException : public LinesideException {
+  public:
+    explicit ItemIdMismatchException(const ItemId exp, const ItemId act) :
+      LinesideException(""),
+      expected(exp),
+      actual(act),
+      message() {
+      std::stringstream tmp;
+      tmp << "Expected " << this->expected;
+      tmp << " but Got " << this->actual;
+      this->message = tmp.str();
+    }
+    
+    const ItemId expected;
+    const ItemId actual;
+    std::string message;
+
+    virtual const char* what() const noexcept override {
+      return this->message.c_str();
+    }
   };
 
   // ========================================

--- a/include/notifiable.hpp
+++ b/include/notifiable.hpp
@@ -8,6 +8,6 @@ namespace Lineside {
     virtual ~Notifiable() {}
     
     //! Method to be called when some event occurs
-    virtual void Notify(const int sourceId, const NotificationType notification) = 0;
+    virtual void Notify(const unsigned int sourceId, const NotificationType notification) = 0;
   };
 }

--- a/include/notifier.hpp
+++ b/include/notifier.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "notifiable.hpp"
 

--- a/include/notifier.hpp
+++ b/include/notifier.hpp
@@ -12,7 +12,7 @@ namespace Lineside {
     Notifier() :
       listeners() {}
     
-    void Register(const int requestedSourceId,
+    void Register(const unsigned int requestedSourceId,
 		  std::weak_ptr<Notifiable<NotificationType>> target) {
       this->listeners.push_back(Listener(requestedSourceId, target));
     }
@@ -32,11 +32,11 @@ namespace Lineside {
     
   private:
     struct Listener {
-      Listener(int reqSrcId, std::weak_ptr<Notifiable<NotificationType>> l) :
+      Listener(unsigned int reqSrcId, std::weak_ptr<Notifiable<NotificationType>> l) :
 	requestedSourceId(reqSrcId),
 	listener(l) {}
       
-      const int requestedSourceId;
+      const unsigned int requestedSourceId;
       std::weak_ptr<Notifiable<NotificationType>> listener;
     };
     

--- a/include/pwitemcontroller.hpp
+++ b/include/pwitemcontroller.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <memory>
+
+#include "itemid.hpp"
+
+namespace Lineside {
+  class PWItemModel;
+  
+  //! Contoller for a Permanent Way Item
+  class PWItemController {
+  public:
+    void Activate();
+
+    void Run();
+    
+    void Deactivate();
+
+    void NotifyUpdate();
+  private:
+    ItemId id;
+    std::shared_ptr<PWItemModel> model;
+
+    std::thread t;
+    std::mutex mtx;
+    std::condition_variable cv;
+  };
+}

--- a/include/pwitemcontroller.hpp
+++ b/include/pwitemcontroller.hpp
@@ -25,6 +25,9 @@ namespace Lineside {
     void Run();
     
     void Deactivate();
+
+    virtual void Notify(const unsigned int sourceId,
+			const bool notification) override;
   private:
     enum class ControllerState { Constructed, Active, Inactive };
     

--- a/include/pwitemcontroller.hpp
+++ b/include/pwitemcontroller.hpp
@@ -5,21 +5,22 @@
 #include <condition_variable>
 #include <memory>
 
+#include "notifiable.hpp"
+
 #include "itemid.hpp"
 
 namespace Lineside {
   class PWItemModel;
   
   //! Contoller for a Permanent Way Item
-  class PWItemController {
+  class PWItemController : public Notifiable<bool>,
+			   public std::enable_shared_from_this<PWItemController> {
   public:
     void Activate();
 
     void Run();
     
     void Deactivate();
-
-    void NotifyUpdate();
   private:
     ItemId id;
     std::shared_ptr<PWItemModel> model;

--- a/include/pwitemcontroller.hpp
+++ b/include/pwitemcontroller.hpp
@@ -38,6 +38,7 @@ namespace Lineside {
 			const bool notification) override;
   private:
     enum class ControllerState { Constructed, Active, Inactive };
+    const std::chrono::seconds MaximumWaitSeconds = std::chrono::seconds(5);
     
     std::shared_ptr<PWItemModel> model;
     ItemId id;
@@ -46,5 +47,7 @@ namespace Lineside {
     std::thread t;
     std::mutex mtx;
     std::condition_variable cv;
+
+    bool CheckWakeUp() const;
   };
 }

--- a/include/pwitemcontroller.hpp
+++ b/include/pwitemcontroller.hpp
@@ -11,24 +11,11 @@
 
 namespace Lineside {
   class PWItemModel;
-  
-  //! Contoller for a Permanent Way Item
-  class PWItemController : public Notifiable<bool>,
-			   public std::enable_shared_from_this<PWItemController> {
-  public:
-    PWItemController(std::shared_ptr<PWItemModel> pwim) :
-      Notifiable<bool>(),
-      std::enable_shared_from_this<PWItemController>(),
-      model(pwim),
-      id(pwim->getId()),
-      state(ControllerState::Constructed),
-      t(),
-      mtx(),
-      cv() {
-      // Nothing to do
-    }
 
-    ~PWItemController();
+  //! Contoller for a Permanent Way Item
+  class PWItemController : public Notifiable<bool> {
+  public:
+    virtual ~PWItemController();
     
     void Activate();
     
@@ -36,6 +23,9 @@ namespace Lineside {
 
     virtual void Notify(const unsigned int sourceId,
 			const bool notification) override;
+
+    static std::shared_ptr<PWItemController> Construct(std::shared_ptr<PWItemModel> pwim);
+    
   private:
     enum class ControllerState { Constructed, Active, Inactive };
     const std::chrono::seconds MaximumWaitSeconds = std::chrono::seconds(5);
@@ -47,6 +37,17 @@ namespace Lineside {
     std::thread t;
     std::mutex mtx;
     std::condition_variable cv;
+    
+    PWItemController() :
+      Notifiable<bool>(),
+      model(),
+      id(),
+      state(ControllerState::Constructed),
+      t(),
+      mtx(),
+      cv() {
+      // Nothing to do
+    }
 
     bool CheckWakeUp() const;
 

--- a/include/pwitemcontroller.hpp
+++ b/include/pwitemcontroller.hpp
@@ -15,8 +15,16 @@ namespace Lineside {
   //! Contoller for a Permanent Way Item
   class PWItemController : public Notifiable<bool>,
 			   public std::enable_shared_from_this<PWItemController> {
-  public:    
-    PWItemController(std::shared_ptr<PWItemModel> pwim);
+  public:
+    PWItemController(std::shared_ptr<PWItemModel> pwim) :
+      model(pwim),
+      id(pwim->getId()),
+      state(ControllerState::Constructed),
+      t(),
+      mtx(),
+      cv() {
+      // Nothing to do
+    }
 
     ~PWItemController();
     
@@ -31,8 +39,8 @@ namespace Lineside {
   private:
     enum class ControllerState { Constructed, Active, Inactive };
     
-    ItemId id;
     std::shared_ptr<PWItemModel> model;
+    ItemId id;
     ControllerState state;
 
     std::thread t;

--- a/include/pwitemcontroller.hpp
+++ b/include/pwitemcontroller.hpp
@@ -12,18 +12,27 @@
 namespace Lineside {
   class PWItemModel;
 
-  //! Contoller for a Permanent Way Item
+  //! Controller for a Permanent Way Item
+  /*!
+    This class is responsible for the _managing_ thread associated with an item
+    on the permanent way (such as a multiaspect signal head or a track circuit).
+    The state of the item itself is the responsibility of the corresponding
+    PWItemModel object.
+   */
   class PWItemController : public Notifiable<bool> {
   public:
     virtual ~PWItemController();
-    
+
+    //! Start up the managing thread and use it to run the model
     void Activate();
-    
+
+    //! Shut down the managing thread
     void Deactivate();
 
     virtual void Notify(const unsigned int sourceId,
 			const bool notification) override;
 
+    //! Create a PWItemController for the supplied model
     static std::shared_ptr<PWItemController> Construct(std::shared_ptr<PWItemModel> pwim);
     
   private:

--- a/include/pwitemcontroller.hpp
+++ b/include/pwitemcontroller.hpp
@@ -29,8 +29,6 @@ namespace Lineside {
     ~PWItemController();
     
     void Activate();
-
-    void Run();
     
     void Deactivate();
 
@@ -49,5 +47,7 @@ namespace Lineside {
     std::condition_variable cv;
 
     bool CheckWakeUp() const;
+
+    void Run();
   };
 }

--- a/include/pwitemcontroller.hpp
+++ b/include/pwitemcontroller.hpp
@@ -15,8 +15,10 @@ namespace Lineside {
   //! Contoller for a Permanent Way Item
   class PWItemController : public Notifiable<bool>,
 			   public std::enable_shared_from_this<PWItemController> {
-  public:
+  public:    
     PWItemController(std::shared_ptr<PWItemModel> pwim);
+
+    ~PWItemController();
     
     void Activate();
 
@@ -24,8 +26,11 @@ namespace Lineside {
     
     void Deactivate();
   private:
+    enum class ControllerState { Constructed, Active, Inactive };
+    
     ItemId id;
     std::shared_ptr<PWItemModel> model;
+    ControllerState state;
 
     std::thread t;
     std::mutex mtx;

--- a/include/pwitemcontroller.hpp
+++ b/include/pwitemcontroller.hpp
@@ -17,6 +17,8 @@ namespace Lineside {
 			   public std::enable_shared_from_this<PWItemController> {
   public:
     PWItemController(std::shared_ptr<PWItemModel> pwim) :
+      Notifiable<bool>(),
+      std::enable_shared_from_this<PWItemController>(),
       model(pwim),
       id(pwim->getId()),
       state(ControllerState::Constructed),

--- a/include/pwitemcontroller.hpp
+++ b/include/pwitemcontroller.hpp
@@ -16,6 +16,8 @@ namespace Lineside {
   class PWItemController : public Notifiable<bool>,
 			   public std::enable_shared_from_this<PWItemController> {
   public:
+    PWItemController(std::shared_ptr<PWItemModel> pwim);
+    
     void Activate();
 
     void Run();

--- a/include/pwitemmodel.hpp
+++ b/include/pwitemmodel.hpp
@@ -7,9 +7,11 @@
 #include "itemid.hpp"
 
 namespace Lineside {
-
   class PWItemModel {
   public:
+    PWItemModel(const ItemId itemId) :
+      id(itemId) {}
+    
     virtual ~PWItemModel() {}
 
     ItemId getId() const {
@@ -24,7 +26,7 @@ namespace Lineside {
 
     virtual bool HaveStateChange() = 0;
 
-    void RegisterController(const int reqSrcId,
+    void RegisterController(const unsigned int reqSrcId,
 			    std::weak_ptr<Notifiable<bool>> target);
   private:
     ItemId id;

--- a/include/pwitemmodel.hpp
+++ b/include/pwitemmodel.hpp
@@ -28,6 +28,8 @@ namespace Lineside {
 
     void RegisterController(const unsigned int reqSrcId,
 			    std::weak_ptr<Notifiable<bool>> target);
+
+    void WakeController();
   private:
     ItemId id;
     Notifier<bool> controllerNotifier;

--- a/include/pwitemmodel.hpp
+++ b/include/pwitemmodel.hpp
@@ -2,10 +2,11 @@
 
 #include <chrono>
 
+#include "notifier.hpp"
+
 #include "itemid.hpp"
 
 namespace Lineside {
-  class PWItemController;
 
   class PWItemModel {
   public:
@@ -16,8 +17,11 @@ namespace Lineside {
     virtual std::chrono::milliseconds OnRun() = 0;
 
     virtual bool HaveStateChange() = 0;
+
+    void RegisterController(const int reqSrcId,
+			    std::weak_ptr<Notifiable<bool>> target);
   private:
     ItemId id;
-    std::weak_ptr<PWItemController> controller;
+    Notifier<bool> controllerNotifier;
   };
 }

--- a/include/pwitemmodel.hpp
+++ b/include/pwitemmodel.hpp
@@ -7,6 +7,16 @@
 #include "itemid.hpp"
 
 namespace Lineside {
+  //! Base class for Permanent Way Items
+  /*!
+    These are the pieces of hardware monitored or controlled by this program.
+    Some examples are track circuits and turnout motors. This class works
+    together with the PWItemController, which is responsible for managing
+    the thread which runs instances of this class.
+
+    Code in this class is executed by either the _managing_ thread (owned by
+    the associated PWItemController) or the _main_ thread (of the program).
+   */
   class PWItemModel {
   public:
     PWItemModel(const ItemId itemId) :
@@ -15,21 +25,47 @@ namespace Lineside {
     
     virtual ~PWItemModel() {}
 
+    //! Returns the id of this permanent way item
     ItemId getId() const {
       return this->id;
     }
-    
-    virtual void OnActivate() = 0;
 
-    virtual void OnDeactivate() = 0;
-    
+    //! Hook to perform any required setup tasks on the managing thread
+    virtual void OnActivate() {}
+
+    //! Hook to perform any required tasks prior to the termination of the managing thread
+    virtual void OnDeactivate() {}
+
+    //! Hook to interact with the hardware
+    /*!
+      The managing thread calls this repeatedly, enabling the subclasses to
+      manipulate their associated hardware. The return value is a request for
+      a sleep interval before this method is called again (if WakeController()
+      is not called first).
+
+      \b Note The PWItemController class caps the time which may elapse prior
+      to the next call of this method. It is not possible to request to sleep
+      until there is a state change. Subclasses should ensure that their
+      implementations of this method are suitably idempotent.
+
+      \retval Requested time before next call
+     */
     virtual std::chrono::milliseconds OnRun() = 0;
 
+    //! Indicate whether or not the state of the item needs to change
+    /*!
+      This method is used to guard against spurious wakeups of the
+      managing thread. The OnRun() method will only be called if
+      this method returns true (or the duration specified by the
+      last OnRun() call has elapsed).
+     */
     virtual bool HaveStateChange() = 0;
 
+    //! Setup the communication link between this object and the corresponding PWItemController
     void RegisterController(const unsigned int reqSrcId,
 			    std::weak_ptr<Notifiable<bool>> target);
 
+    //! Sends a wake up notification to the managing thread
     void WakeController();
   private:
     ItemId id;

--- a/include/pwitemmodel.hpp
+++ b/include/pwitemmodel.hpp
@@ -10,6 +10,12 @@ namespace Lineside {
 
   class PWItemModel {
   public:
+    virtual ~PWItemModel() {}
+
+    ItemId getId() const {
+      return this->id;
+    }
+    
     virtual void OnActivate() = 0;
 
     virtual void OnDeactivate() = 0;

--- a/include/pwitemmodel.hpp
+++ b/include/pwitemmodel.hpp
@@ -10,7 +10,8 @@ namespace Lineside {
   class PWItemModel {
   public:
     PWItemModel(const ItemId itemId) :
-      id(itemId) {}
+      id(itemId),
+      controllerNotifier() {}
     
     virtual ~PWItemModel() {}
 

--- a/include/pwitemmodel.hpp
+++ b/include/pwitemmodel.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <chrono>
+
+#include "itemid.hpp"
+
+namespace Lineside {
+  class PWItemController;
+
+  class PWItemModel {
+  public:
+    virtual void OnActivate() = 0;
+
+    virtual void OnDeactivate() = 0;
+    
+    virtual std::chrono::milliseconds OnRun() = 0;
+
+    virtual bool HaveStateChange() = 0;
+  private:
+    ItemId id;
+    std::weak_ptr<PWItemController> controller;
+  };
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ set( srcs )
 
 list(APPEND srcs itemid.cpp)
 list(APPEND srcs binaryinputpin.cpp)
+list(APPEND srcs pwitemcontroller.cpp)
 
 add_library( lineside ${srcs} )
 target_include_directories(lineside

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ set( srcs )
 
 list(APPEND srcs itemid.cpp)
 list(APPEND srcs binaryinputpin.cpp)
+list(APPEND srcs pwitemmodel.cpp)
 list(APPEND srcs pwitemcontroller.cpp)
 
 add_library( lineside ${srcs} )

--- a/src/binaryinputpin.cpp
+++ b/src/binaryinputpin.cpp
@@ -1,7 +1,7 @@
 #include "binaryinputpin.hpp"
 
 namespace Lineside {
-  void BinaryInputPin::RegisterListener(const int requestedSourceId,
+  void BinaryInputPin::RegisterListener(const unsigned int requestedSourceId,
 					std::weak_ptr<Notifiable<bool>> listener) {
     this->notifier.Register(requestedSourceId, listener);
   }

--- a/src/pwitemcontroller.cpp
+++ b/src/pwitemcontroller.cpp
@@ -1,3 +1,4 @@
+#include <stdexcept>
 #include "pwitemmodel.hpp"
 
 #include "pwitemcontroller.hpp"
@@ -6,10 +7,28 @@ namespace Lineside {
   PWItemController::PWItemController(std::shared_ptr<PWItemModel> pwim) :
     id(pwim->getId()),
     model(pwim),
+    state(ControllerState::Constructed),
     t(),
     mtx(),
     cv() {
-    
+    this->model->RegisterController(this->id.Get(),
+				    this->shared_from_this());
   }
 
+  PWItemController::~PWItemController() {
+
+  }
+
+  void PWItemController::Activate() {
+    throw std::logic_error(__FUNCTION__);
+  }
+
+  void PWItemController::Run() {
+    throw std::logic_error(__FUNCTION__);
+  }
+
+  void PWItemController::Deactivate() {
+    this->state = ControllerState::Inactive;
+    throw std::logic_error(__FUNCTION__);
+  }
 }

--- a/src/pwitemcontroller.cpp
+++ b/src/pwitemcontroller.cpp
@@ -9,6 +9,20 @@
 #include "pwitemcontroller.hpp"
 
 namespace Lineside {
+  std::shared_ptr<PWItemController> PWItemController::Construct(std::shared_ptr<PWItemModel> pwim) {
+    std::shared_ptr<PWItemController> result;
+
+    // Work around the private constructor of PWItemController
+    struct enabler : public PWItemController {};
+    
+    result = std::make_shared<enabler>();
+    result->id = pwim->getId();
+    result->model = pwim;
+    result->model->RegisterController(result->id.Get(), result);
+
+    return result;
+  }
+  
   PWItemController::~PWItemController() {
     this->Deactivate();
     if( this->t.joinable() ) {
@@ -22,9 +36,6 @@ namespace Lineside {
       msg << "Improper Activate() call on " << this->id;
       throw std::logic_error(msg.str());
     }
-    
-    this->model->RegisterController(this->id.Get(),
-				    this->shared_from_this());
 
     // Spawn the thread using condition variable
     // to ensure it is active before this function exits

--- a/src/pwitemcontroller.cpp
+++ b/src/pwitemcontroller.cpp
@@ -1,4 +1,8 @@
 #include <stdexcept>
+#include <sstream>
+
+#include <boost/predef.h>
+
 #include "pwitemmodel.hpp"
 
 #include "pwitemcontroller.hpp"
@@ -13,6 +17,7 @@ namespace Lineside {
     cv() {
     this->model->RegisterController(this->id.Get(),
 				    this->shared_from_this());
+    std::cout << __PRETTY_FUNCTION__ << ": Complete" << std::endl;
   }
 
   PWItemController::~PWItemController() {
@@ -31,4 +36,29 @@ namespace Lineside {
     this->state = ControllerState::Inactive;
     throw std::logic_error(__FUNCTION__);
   }
+
+#if defined(BOOST_COMP_GNUC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#elif defined(BOOST_COMP_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+  void PWItemController::Notify(const unsigned int sourceId,
+				const bool notification) {
+    if( sourceId != this->id.Get() ) {
+      std::stringstream msg;
+      msg << __PRETTY_FUNCTION__
+	  << ": Mismatched sourceId. "
+	  << "Got(" << sourceId << ") "
+	  << "Expected(" << this->id << ")";
+      throw std::runtime_error(msg.str());
+    }
+    throw std::logic_error(__FUNCTION__);
+  }
+#if defined(BOOST_COMP_GNUC)
+#pragma GCC diagnostic pop
+#elif defined(BOOST_COMP_CLANG)
+#pragma clange diagnostic pop
+#endif
 }

--- a/src/pwitemcontroller.cpp
+++ b/src/pwitemcontroller.cpp
@@ -61,25 +61,16 @@ namespace Lineside {
     this->cv.notify_one();
   }
 
-#if defined(BOOST_COMP_GNUC)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#elif defined(BOOST_COMP_CLANG)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#endif
   void PWItemController::Notify(const unsigned int sourceId,
 				const bool notification) {
+    if( !notification ) {
+      throw std::logic_error("Unexpected notification to PWItemController::Notify");
+    }
     if( sourceId != this->id.Get() ) {
       throw ItemIdMismatchException( this->id, sourceId );
     }
-    throw std::logic_error(__FUNCTION__);
+    this->cv.notify_one();
   }
-#if defined(BOOST_COMP_GNUC)
-#pragma GCC diagnostic pop
-#elif defined(BOOST_COMP_CLANG)
-#pragma clange diagnostic pop
-#endif
 
   bool PWItemController::CheckWakeUp() const {
     bool shouldWake = (this->state != ControllerState::Active);

--- a/src/pwitemcontroller.cpp
+++ b/src/pwitemcontroller.cpp
@@ -16,7 +16,13 @@ namespace Lineside {
     }
   }
 
-  void PWItemController::Activate() {    
+  void PWItemController::Activate() {
+    if( this->state != ControllerState::Constructed ) {
+      std::stringstream msg;
+      msg << "Improper Activate() call on " << this->id;
+      throw std::logic_error(msg.str());
+    }
+    
     this->model->RegisterController(this->id.Get(),
 				    this->shared_from_this());
 

--- a/src/pwitemcontroller.cpp
+++ b/src/pwitemcontroller.cpp
@@ -3,21 +3,12 @@
 
 #include <boost/predef.h>
 
+#include "linesideexceptions.hpp"
 #include "pwitemmodel.hpp"
 
 #include "pwitemcontroller.hpp"
 
 namespace Lineside {
-  PWItemController::PWItemController(std::shared_ptr<PWItemModel> pwim) :
-    id(pwim->getId()),
-    model(pwim),
-    state(ControllerState::Constructed),
-    t(),
-    mtx(),
-    cv() {
-    // Nothing to do
-  }
-
   PWItemController::~PWItemController() {
 
   }
@@ -47,12 +38,7 @@ namespace Lineside {
   void PWItemController::Notify(const unsigned int sourceId,
 				const bool notification) {
     if( sourceId != this->id.Get() ) {
-      std::stringstream msg;
-      msg << __PRETTY_FUNCTION__
-	  << ": Mismatched sourceId. "
-	  << "Got(" << sourceId << ") "
-	  << "Expected(" << this->id << ")";
-      throw std::runtime_error(msg.str());
+      throw ItemIdMismatchException( this->id, sourceId );
     }
     throw std::logic_error(__FUNCTION__);
   }

--- a/src/pwitemcontroller.cpp
+++ b/src/pwitemcontroller.cpp
@@ -15,9 +15,7 @@ namespace Lineside {
     t(),
     mtx(),
     cv() {
-    this->model->RegisterController(this->id.Get(),
-				    this->shared_from_this());
-    std::cout << __PRETTY_FUNCTION__ << ": Complete" << std::endl;
+    // Nothing to do
   }
 
   PWItemController::~PWItemController() {
@@ -25,6 +23,8 @@ namespace Lineside {
   }
 
   void PWItemController::Activate() {
+    this->model->RegisterController(this->id.Get(),
+				    this->shared_from_this());
     throw std::logic_error(__FUNCTION__);
   }
 

--- a/src/pwitemcontroller.cpp
+++ b/src/pwitemcontroller.cpp
@@ -1,0 +1,15 @@
+#include "pwitemmodel.hpp"
+
+#include "pwitemcontroller.hpp"
+
+namespace Lineside {
+  PWItemController::PWItemController(std::shared_ptr<PWItemModel> pwim) :
+    id(pwim->getId()),
+    model(pwim),
+    t(),
+    mtx(),
+    cv() {
+    
+  }
+
+}

--- a/src/pwitemmodel.cpp
+++ b/src/pwitemmodel.cpp
@@ -1,0 +1,8 @@
+#include "pwitemmodel.hpp"
+
+namespace Lineside {
+  void PWItemModel::RegisterController(const unsigned int reqSrcId,
+				       std::weak_ptr<Notifiable<bool>> target) {
+    this->controllerNotifier.Register(reqSrcId, target);
+  }
+}

--- a/src/pwitemmodel.cpp
+++ b/src/pwitemmodel.cpp
@@ -3,8 +3,6 @@
 namespace Lineside {
   void PWItemModel::RegisterController(const unsigned int reqSrcId,
 				       std::weak_ptr<Notifiable<bool>> target) {
-    std::cout << __PRETTY_FUNCTION__ << ": BEGIN" << std::endl;
     this->controllerNotifier.Register(reqSrcId, target);
-    std::cout << __PRETTY_FUNCTION__ << ": END" << std::endl;
   }
 }

--- a/src/pwitemmodel.cpp
+++ b/src/pwitemmodel.cpp
@@ -5,4 +5,8 @@ namespace Lineside {
 				       std::weak_ptr<Notifiable<bool>> target) {
     this->controllerNotifier.Register(reqSrcId, target);
   }
+
+  void PWItemModel::WakeController() {
+    this->controllerNotifier.Notify(true);
+  }
 }

--- a/src/pwitemmodel.cpp
+++ b/src/pwitemmodel.cpp
@@ -3,6 +3,8 @@
 namespace Lineside {
   void PWItemModel::RegisterController(const unsigned int reqSrcId,
 				       std::weak_ptr<Notifiable<bool>> target) {
+    std::cout << __PRETTY_FUNCTION__ << ": BEGIN" << std::endl;
     this->controllerNotifier.Register(reqSrcId, target);
+    std::cout << __PRETTY_FUNCTION__ << ": END" << std::endl;
   }
 }

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -7,6 +7,7 @@ list(APPEND srcs itemidtests.cpp)
 list(APPEND srcs exceptiontests.cpp)
 list(APPEND srcs registrartests.cpp)
 list(APPEND srcs mockbiptests.cpp)
+list(APPEND srcs pwitemcontrollertests.cpp)
 
 add_executable( LinesideTest ${srcs} )
 target_include_directories(LinesideTest

--- a/tst/exceptionmessagecheck.hpp
+++ b/tst/exceptionmessagecheck.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <sstream>
+
+#include <boost/test/unit_test.hpp>
+
+template<typename T>
+std::function<bool(const T&)> GetExceptionMessageChecker( std::string expected ) {
+  return [=]( const T& e ) {
+    std::stringstream stream;
+    stream << "Exception Message: " << e.what() << std::endl;
+    stream << "         Expected: " << expected << std::endl;
+    BOOST_TEST_INFO(stream.str());
+    return expected == e.what();
+  };
+}

--- a/tst/exceptiontests.cpp
+++ b/tst/exceptiontests.cpp
@@ -6,6 +6,18 @@
 
 BOOST_AUTO_TEST_SUITE(LinesideExceptions)
 
+BOOST_AUTO_TEST_CASE(ItemIdMismatchException)
+{
+  Lineside::ItemId exp(1), act(2);
+
+  Lineside::ItemIdMismatchException ime(exp, act);
+  BOOST_CHECK_EQUAL( ime.expected, exp );
+  BOOST_CHECK_EQUAL( ime.actual, act );
+
+  const std::string expected = "Expected 00:00:00:01 but Got 00:00:00:02";
+  BOOST_CHECK_EQUAL(expected, ime.what());
+}
+
 BOOST_AUTO_TEST_CASE(KeyNotFoundException)
 {
   Lineside::KeyNotFoundException knfe("myKey");

--- a/tst/mockbiptests.cpp
+++ b/tst/mockbiptests.cpp
@@ -16,10 +16,10 @@ public:
     lastNotificationSource(0),
     lastNotification(false) {}
   
-  int lastNotificationSource;
+  unsigned int lastNotificationSource;
   bool lastNotification;
 
-  virtual void Notify(const int sourceId, const bool notification) override {
+  virtual void Notify(const unsigned int sourceId, const bool notification) override {
     this->lastNotificationSource = sourceId;
     this->lastNotification = notification;
   }

--- a/tst/pwitemcontrollertests.cpp
+++ b/tst/pwitemcontrollertests.cpp
@@ -1,0 +1,42 @@
+#include <boost/test/unit_test.hpp>
+
+#include "pwitemmodel.hpp"
+#include "pwitemcontroller.hpp"
+
+// ===================================
+
+class MockModel : public Lineside::PWItemModel {
+public:
+  MockModel(Lineside::ItemId id) : Lineside::PWItemModel(id) {}
+  
+  virtual void OnActivate() override {
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+
+  virtual void OnDeactivate() override {
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+
+  virtual std::chrono::milliseconds OnRun() override {
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+
+  virtual bool HaveStateChange() override {
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+};
+
+// ===================================
+
+BOOST_AUTO_TEST_SUITE(PWItemController)
+
+BOOST_AUTO_TEST_CASE(BasicLifeCycle)
+{
+  Lineside::ItemId id = Lineside::ItemId::Random();
+  auto model = std::make_shared<MockModel>(id);
+
+  auto controller = std::make_shared<Lineside::PWItemController>(model);
+  BOOST_CHECK_EQUAL(controller.use_count(), 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/pwitemcontrollertests.cpp
+++ b/tst/pwitemcontrollertests.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(BasicLifeCycle, *boost::unit_test::timeout(2))
   Lineside::ItemId id = Lineside::ItemId::Random();
   auto model = std::make_shared<MockModel>(id);
 
-  auto controller = std::make_shared<Lineside::PWItemController>(model);
+  auto controller = Lineside::PWItemController::Construct(model);
   BOOST_CHECK_EQUAL(controller.use_count(), 1);
   BOOST_CHECK(!model->onActivateCalled);
   BOOST_CHECK_EQUAL(model->onRunCallTimes.size(), 0);
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(ShortDurationSleeps, *boost::unit_test::timeout(2))
 {
   Lineside::ItemId id = Lineside::ItemId::Random();
   auto model = std::make_shared<MockModel>(id);
-  auto controller = std::make_shared<Lineside::PWItemController>(model);
+  auto controller = Lineside::PWItemController::Construct(model);
   BOOST_CHECK_EQUAL(model->onRunCallTimes.size(), 0);
 
   const int nSleepIntervals = 10;
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(LongSleepIgnored, *boost::unit_test::timeout(30))
 {
   Lineside::ItemId id = Lineside::ItemId::Random();
   auto model = std::make_shared<MockModel>(id);
-  auto controller = std::make_shared<Lineside::PWItemController>(model);
+  auto controller = Lineside::PWItemController::Construct(model);
   BOOST_CHECK_EQUAL(model->onRunCallTimes.size(), 0);
 
   // Set too long sleep request
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(DestructorDeactivates, *boost::unit_test::timeout(2))
   auto model = std::make_shared<MockModel>(id);
   model->onRunWait = std::chrono::seconds(4);
   {
-    auto controller = std::make_shared<Lineside::PWItemController>(model);
+    auto controller = Lineside::PWItemController::Construct(model);
     controller->Activate();
   }
   BOOST_CHECK( model->onDeactivateCalled );
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(ModelCanNotify, *boost::unit_test::timeout(2))
 {
   Lineside::ItemId id = Lineside::ItemId::Random();
   auto model = std::make_shared<MockModel>(id);
-  auto controller = std::make_shared<Lineside::PWItemController>(model);
+  auto controller = Lineside::PWItemController::Construct(model);
   BOOST_CHECK_EQUAL(model->onRunCallTimes.size(), 0);
 
   model->onRunWait = std::chrono::seconds(4);
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(IncorrectActivate, *boost::unit_test::timeout(2))
 {
   Lineside::ItemId id = Lineside::ItemId::Random();
   auto model = std::make_shared<MockModel>(id);
-  auto controller = std::make_shared<Lineside::PWItemController>(model);
+  auto controller = Lineside::PWItemController::Construct(model);
 
   controller->Activate();
 
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(DeactivateWithoutActivate, *boost::unit_test::timeout(1))
 {
   Lineside::ItemId id = Lineside::ItemId::Random();
   auto model = std::make_shared<MockModel>(id);
-  auto controller = std::make_shared<Lineside::PWItemController>(model);
+  auto controller = Lineside::PWItemController::Construct(model);
 
   BOOST_CHECK_NO_THROW( controller->Deactivate() );
 }

--- a/tst/pwitemcontrollertests.cpp
+++ b/tst/pwitemcontrollertests.cpp
@@ -84,6 +84,7 @@ BOOST_AUTO_TEST_CASE(BasicLifeCycle, *boost::unit_test::timeout(2))
   BOOST_CHECK_EQUAL(model->onRunCallTimes.size(), 0);
 
   controller->Activate();
+  PauseForThread();
   BOOST_CHECK(model->onActivateCalled);
   BOOST_CHECK( std::this_thread::get_id() != model->runThreadId );
 

--- a/tst/pwitemcontrollertests.cpp
+++ b/tst/pwitemcontrollertests.cpp
@@ -69,7 +69,7 @@ void PauseForThread() {
 
 BOOST_AUTO_TEST_SUITE(PWItemController)
 
-BOOST_AUTO_TEST_CASE(BasicLifeCycle)
+BOOST_AUTO_TEST_CASE(BasicLifeCycle, *boost::unit_test::timeout(2))
 {
   Lineside::ItemId id = Lineside::ItemId::Random();
   auto model = std::make_shared<MockModel>(id);
@@ -141,6 +141,17 @@ BOOST_AUTO_TEST_CASE(LongSleepIgnored, *boost::unit_test::timeout(30))
   // Should get at least four OnRun() calls due to MaximumWaitTime
   BOOST_CHECK_GE( model->onRunCallTimes.size(), 4 );
   
+}
+
+BOOST_AUTO_TEST_CASE(DestructorDeactivates, *boost::unit_test::timeout(2))
+{
+  Lineside::ItemId id = Lineside::ItemId::Random();
+  auto model = std::make_shared<MockModel>(id);
+  {
+    auto controller = std::make_shared<Lineside::PWItemController>(model);
+    controller->Activate();
+  }
+  BOOST_CHECK( model->onDeactivateCalled );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/pwitemcontrollertests.cpp
+++ b/tst/pwitemcontrollertests.cpp
@@ -7,14 +7,29 @@
 
 class MockModel : public Lineside::PWItemModel {
 public:
-  MockModel(Lineside::ItemId id) : Lineside::PWItemModel(id) {}
+  MockModel(Lineside::ItemId id) :
+    Lineside::PWItemModel(id),
+    onActivateCalled(false),
+    onDeactivateCalled(false),
+    runThreadId(),
+    onRunCallTimes() {}
   
   virtual void OnActivate() override {
-    throw std::logic_error(__PRETTY_FUNCTION__);
+    if(this->onActivateCalled) {
+      throw std::logic_error("Double call OnActivate");
+    }
+    this->onActivateCalled = true;
+    this->runThreadId = std::this_thread::get_id();
   }
 
   virtual void OnDeactivate() override {
-    throw std::logic_error(__PRETTY_FUNCTION__);
+    if(this->onDeactivateCalled) {
+      throw std::logic_error("Double call OnDeactivate");
+    }
+    if( !this->onActivateCalled ) {
+      throw std::logic_error("OnDeactivate called before OnActivate");
+    }
+    this->onDeactivateCalled = true;
   }
 
   virtual std::chrono::milliseconds OnRun() override {
@@ -24,6 +39,11 @@ public:
   virtual bool HaveStateChange() override {
     throw std::logic_error(__PRETTY_FUNCTION__);
   }
+
+  bool onActivateCalled;
+  bool onDeactivateCalled;
+  std::thread::id runThreadId;
+  std::vector<std::chrono::high_resolution_clock::time_point> onRunCallTimes;
 };
 
 // ===================================
@@ -37,6 +57,13 @@ BOOST_AUTO_TEST_CASE(BasicLifeCycle)
 
   auto controller = std::make_shared<Lineside::PWItemController>(model);
   BOOST_CHECK_EQUAL(controller.use_count(), 1);
+  BOOST_CHECK(!model->onActivateCalled);
+  BOOST_CHECK_EQUAL(model->onRunCallTimes.size(), 0);
+
+  controller->Activate();
+  BOOST_CHECK(model->onActivateCalled);
+  BOOST_CHECK_EQUAL(model->onRunCallTimes.size(), 1);
+  BOOST_CHECK( std::this_thread::get_id() != model->runThreadId );
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Create the basic infrastructure for permanent way items. The two principal classes for this are
- `PWItemModel` for managing the hardware state
- `PWItemController` for managing a thread for the `PWItemModel`

Since the `PWItemModel` is little more than an abstraction (with a few very basic methods for handling communication with the `PWItemController` there are no tests for it. Test coverage is provided by those for the `PWItemController` itself.