### PR TITLE
Add model for servo turnouts

### DIFF
--- a/include/devicerequestdata.hpp
+++ b/include/devicerequestdata.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+#include <map>
+
+namespace Lineside {
+  class DeviceRequestData {
+  public:
+    DeviceRequestData() :
+      controller("unset"),
+      controllerData("unset"),
+      settings() {}
+    
+    std::string controller;
+    std::string controllerData;
+    std::map<std::string,std::string> settings;
+  };
+}

--- a/include/hardwaremanager.hpp
+++ b/include/hardwaremanager.hpp
@@ -30,8 +30,8 @@ namespace Lineside {
   public:
     virtual ~HardwareManager() {}
 
-    virtual BOPProviderRegistrar* GetBOPProviderRegistrar() = 0;
-    virtual BIPProviderRegistrar* GetBIPProviderRegistrar() = 0;
-    virtual PWMCProviderRegistrar* GetPWMCProviderRegistrar() = 0;
+    virtual std::weak_ptr<BOPProviderRegistrar> GetBOPProviderRegistrar() = 0;
+    virtual std::weak_ptr<BIPProviderRegistrar> GetBIPProviderRegistrar() = 0;
+    virtual std::weak_ptr<PWMCProviderRegistrar> GetPWMCProviderRegistrar() = 0;
   };
 }

--- a/include/hardwareprovider.hpp
+++ b/include/hardwareprovider.hpp
@@ -17,6 +17,6 @@ namespace Lineside {
     virtual ~HardwareProvider() {}
 
     virtual std::weak_ptr<Hardware> GetHardware(const std::string& hardwareId,
-						const std::map<std::string,std::string>& settings ) = 0;
+						const std::map<std::string,std::string>& settings) = 0;
   };
 }

--- a/include/hardwareprovider.hpp
+++ b/include/hardwareprovider.hpp
@@ -16,7 +16,7 @@ namespace Lineside {
 
     virtual ~HardwareProvider() {}
 
-    virtual std::shared_ptr<Hardware> GetHardware( const std::string& hardwareId,
-						   const std::map<std::string,std::string>& settings ) = 0;
+    virtual std::weak_ptr<Hardware> GetHardware(const std::string& hardwareId,
+						const std::map<std::string,std::string>& settings ) = 0;
   };
 }

--- a/include/hardwareprovider.hpp
+++ b/include/hardwareprovider.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <map>
+#include <memory>
 
 namespace Lineside {
   //! An abstraction of a class which provides hardware access
@@ -15,7 +16,7 @@ namespace Lineside {
 
     virtual ~HardwareProvider() {}
 
-    virtual Hardware* GetHardware( const std::string& hardwareId,
-				   const std::map<std::string,std::string>& settings ) = 0;
+    virtual std::shared_ptr<Hardware> GetHardware( const std::string& hardwareId,
+						   const std::map<std::string,std::string>& settings ) = 0;
   };
 }

--- a/include/linesideexceptions.hpp
+++ b/include/linesideexceptions.hpp
@@ -14,6 +14,33 @@ namespace Lineside {
 
   // ========================================
 
+  //! Exception for failure to lock a std::weak_ptr
+  class PointerLockFailureException : public LinesideException {
+  public:
+    explicit PointerLockFailureException(const std::string file, const unsigned int line) :
+      LinesideException(""),
+      filename(file),
+      linenumber(line),
+      message() {
+      std::stringstream tmp;
+      tmp << "Failed to lock weak_ptr at line "
+	  << this->linenumber
+	  << " of file "
+	  << this->filename;
+      this->message = tmp.str();
+    }
+
+    const std::string filename;
+    const unsigned int linenumber;
+    std::string message;
+    
+    virtual const char* what() const noexcept override {
+      return this->message.c_str();
+    }
+  };
+
+  // ========================================
+
   //! Exception for mismatched ItemIds
   class ItemIdMismatchException : public LinesideException {
   public:

--- a/include/pwitemdata.hpp
+++ b/include/pwitemdata.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <memory>
+
+#include "itemid.hpp"
+#include "pwitemmodel.hpp"
+#include "hardwaremanager.hpp"
+
+namespace Lineside {
+  class PWItemData {
+  public:
+    PWItemData() : id(0) {}
+
+    ItemId id;
+
+    virtual ~PWItemData() {}
+
+    virtual std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw ) = 0;
+  };
+}

--- a/include/registrar.hpp
+++ b/include/registrar.hpp
@@ -2,17 +2,15 @@
 
 #include <map>
 #include <string>
+#include <memory>
 
 #include "linesideexceptions.hpp"
 
 namespace Lineside {
   //! Class to register and retrieve items
   /*!
-    This class wraps a `std::map` from `std::string` to raw pointers
+    This class wraps a `std::map` from `std::string` to weak pointers
     to the specified `ValueType`.
-    Raw pointers are used because this class is for cases where
-    ownership is retained elsewhere (such as hardware access which
-    will be tied to the lifetime of some parent object).
     The returned pointers should only be used for accessing the
     target object, and not controlling its life.
 
@@ -32,7 +30,7 @@ namespace Lineside {
 
     //! Store the target pointer with the given key
     void Register( const std::string& name,
-		   ValueType* target ) {
+		   std::weak_ptr<ValueType> target ) {
       if( this->store.count(name) != 0 ) {
 	throw DuplicateKeyException(name);
       }
@@ -40,13 +38,13 @@ namespace Lineside {
     }
 
     //! Fetch the pointer corresponding to the given key
-    ValueType* Retrieve( const std::string name ) const {
+    std::weak_ptr<ValueType> Retrieve( const std::string name ) const {
       if( this->store.count(name) != 1 ) {
 	throw KeyNotFoundException(name);
       }
       return this->store.at(name);
     }
   private:
-    std::map<std::string,ValueType*> store;
+    std::map<std::string,std::weak_ptr<ValueType>> store;
   };
 }

--- a/include/servoturnoutmotor.hpp
+++ b/include/servoturnoutmotor.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "turnoutmotor.hpp"
+#include "pwmchannel.hpp"
+
+namespace Lineside {
+  class ServoTurnoutMotorData;
+  
+  class ServoTurnoutMotor : public TurnoutMotor {
+  public:
+    const std::chrono::milliseconds SleepInterval = std::chrono::milliseconds(2000);
+    const std::chrono::milliseconds MoveSleep = std::chrono::milliseconds(50);
+    const unsigned int MoveSteps = 10;
+    
+    virtual void OnActivate() override;
+
+    virtual void OnDeactivate() override;
+
+    virtual std::chrono::milliseconds OnRun() override;
+
+    virtual bool HaveStateChange() override;
+
+    virtual void SetState(const TurnoutState desired) override;
+  private:
+    friend class ServoTurnoutMotorData;
+
+    unsigned int pwmStraight;
+    unsigned int pwmCurved;
+    TurnoutState lastState;
+    std::weak_ptr<PWMChannel> servo;
+
+    ServoTurnoutMotor(const ItemId turnoutId) :
+      TurnoutMotor(turnoutId),
+      pwmStraight(),
+      pwmCurved(),
+      lastState(TurnoutState::Straight),
+      servo() {}
+  };
+}

--- a/include/servoturnoutmotor.hpp
+++ b/include/servoturnoutmotor.hpp
@@ -26,14 +26,14 @@ namespace Lineside {
 
     unsigned int pwmStraight;
     unsigned int pwmCurved;
-    TurnoutState lastState;
+    TurnoutState desiredState;
     std::weak_ptr<PWMChannel> servo;
 
     ServoTurnoutMotor(const ItemId turnoutId) :
       TurnoutMotor(turnoutId),
       pwmStraight(),
       pwmCurved(),
-      lastState(TurnoutState::Straight),
+      desiredState(TurnoutState::Straight),
       servo() {}
   };
 }

--- a/include/servoturnoutmotor.hpp
+++ b/include/servoturnoutmotor.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "turnoutmotor.hpp"
 #include "pwmchannel.hpp"
 

--- a/include/servoturnoutmotor.hpp
+++ b/include/servoturnoutmotor.hpp
@@ -28,12 +28,14 @@ namespace Lineside {
     unsigned int pwmCurved;
     TurnoutState desiredState;
     std::weak_ptr<PWMChannel> servo;
+    std::mutex stateChangeMtx;
 
     ServoTurnoutMotor(const ItemId turnoutId) :
       TurnoutMotor(turnoutId),
       pwmStraight(),
       pwmCurved(),
       desiredState(TurnoutState::Straight),
-      servo() {}
+      servo(),
+      stateChangeMtx() {}
   };
 }

--- a/include/servoturnoutmotordata.hpp
+++ b/include/servoturnoutmotordata.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "pwitemdata.hpp"
+#include "devicerequestdata.hpp"
+
+namespace Lineside {
+  class ServoTurnoutMotorData : public PWItemData {
+  public:
+    ServoTurnoutMotorData();
+
+    unsigned int straight;
+    unsigned int curved;
+    DeviceRequestData pwmChannelRequest;
+
+    virtual std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw ) override;
+  };
+}

--- a/include/turnoutmotor.hpp
+++ b/include/turnoutmotor.hpp
@@ -9,7 +9,7 @@ namespace Lineside {
   public:
     virtual void SetState(const TurnoutState desired) = 0;
 
-    virtual TurnoutState getState() const {
+    virtual TurnoutState GetState() const {
       return this->currentState;
     }
     

--- a/include/turnoutmotor.hpp
+++ b/include/turnoutmotor.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "pwitemmodel.hpp"
+
+#include "turnoutstate.hpp"
+
+namespace Lineside {
+  class TurnoutMotor : public PWItemModel {
+  public:
+    virtual void SetState(const TurnoutState desired) = 0;
+
+    virtual TurnoutState getState() const {
+      return this->currentState;
+    }
+    
+  protected:
+    TurnoutState currentState;
+    
+    TurnoutMotor(const ItemId turnoutId) :
+      PWItemModel(turnoutId),
+      currentState(TurnoutState::Straight) {}
+  };
+}

--- a/include/turnoutstate.hpp
+++ b/include/turnoutstate.hpp
@@ -4,4 +4,8 @@ namespace Lineside {
   enum class TurnoutState { Straight,
 			    Curved
   };
+
+  std::ostream& operator<<(std::ostream& os, const TurnoutState s);
+
+  std::string ToString( const TurnoutState s );
 }

--- a/include/turnoutstate.hpp
+++ b/include/turnoutstate.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace Lineside {
+  enum class TurnoutState { Straight,
+			    Curved
+  };
+}

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -1,7 +1,17 @@
+/*! \file utility.hpp
+  \brief Header file for utility bits and pieces
+*/
+
 #pragma once
 
 #include "linesideexceptions.hpp"
 
+//! Macro for locking a weak_ptr
+/*!
+  This locks the weak_ptr \a WP and assigns it to the shared_ptr \a SP. If
+  the \c lock() call fails, a Lineside::PointerLockFailureException is thrown
+  which contains details about the failure location.
+ */
 #define LOCK_OR_THROW(SP, WP) auto SP = WP.lock(); \
   if( !SP ) {								\
     throw Lineside::PointerLockFailureException(__FILE__, __LINE__);	\

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "linesideexceptions.hpp"
+
+#define LOCK_OR_THROW(SP, WP) auto SP = WP.lock(); \
+  if( !SP ) {								\
+    throw Lineside::PointerLockFailureException(__FILE__, __LINE__);	\
+  }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ set( srcs )
 list(APPEND srcs itemid.cpp)
 list(APPEND srcs binaryinputpin.cpp)
 list(APPEND srcs servoturnoutmotordata.cpp)
+list(APPEND srcs servoturnoutmotor.cpp)
 list(APPEND srcs pwitemmodel.cpp)
 list(APPEND srcs pwitemcontroller.cpp)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ set( srcs )
 
 list(APPEND srcs itemid.cpp)
 list(APPEND srcs binaryinputpin.cpp)
+list(APPEND srcs servoturnoutmotordata.cpp)
 list(APPEND srcs pwitemmodel.cpp)
 list(APPEND srcs pwitemcontroller.cpp)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,14 @@
 set( srcs )
 
+list(APPEND srcs turnoutstate.cpp)
+
 list(APPEND srcs itemid.cpp)
 list(APPEND srcs binaryinputpin.cpp)
-list(APPEND srcs servoturnoutmotordata.cpp)
-list(APPEND srcs servoturnoutmotor.cpp)
 list(APPEND srcs pwitemmodel.cpp)
 list(APPEND srcs pwitemcontroller.cpp)
+
+list(APPEND srcs servoturnoutmotordata.cpp)
+list(APPEND srcs servoturnoutmotor.cpp)
 
 add_library( lineside ${srcs} )
 target_include_directories(lineside

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,5 +12,6 @@ list(APPEND srcs servoturnoutmotor.cpp)
 
 add_library( lineside ${srcs} )
 target_include_directories(lineside
-  PUBLIC ${PROJECT_SOURCE_DIR}/include
-  SYSTEM PRIVATE ${Boost_INCLUDE_DIRS})
+  PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_include_directories(lineside SYSTEM
+  PRIVATE ${Boost_INCLUDE_DIRS})

--- a/src/servoturnoutmotor.cpp
+++ b/src/servoturnoutmotor.cpp
@@ -13,6 +13,7 @@ namespace Lineside {
   void ServoTurnoutMotor::OnDeactivate() {}
 
   std::chrono::milliseconds ServoTurnoutMotor::OnRun() {
+    std::lock_guard<std::mutex> lockState(this->stateChangeMtx);
     throw std::logic_error(__PRETTY_FUNCTION__);
   }
 
@@ -21,6 +22,7 @@ namespace Lineside {
   }
 
   void ServoTurnoutMotor::SetState(const TurnoutState desired) {
+    std::lock_guard<std::mutex> lockState(this->stateChangeMtx);
     this->desiredState = desired;
     this->WakeController();
   }

--- a/src/servoturnoutmotor.cpp
+++ b/src/servoturnoutmotor.cpp
@@ -1,0 +1,30 @@
+#include "servoturnoutmotor.hpp"
+
+namespace Lineside {
+  void ServoTurnoutMotor::OnActivate() {
+    auto servoCtrl = this->servo.lock();
+    if( servoCtrl.use_count() == 0 ) {
+      throw std::logic_error("ServoTurnoutMotor: servo pointer expired");
+    }
+    servoCtrl->Set(this->pwmStraight);
+    this->currentState = TurnoutState::Straight;
+    this->lastState = TurnoutState::Straight;
+  }
+
+  void ServoTurnoutMotor::OnDeactivate() {}
+
+  std::chrono::milliseconds ServoTurnoutMotor::OnRun() {
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+
+  bool ServoTurnoutMotor::HaveStateChange() {
+    return this->lastState != this->currentState;
+  }
+
+  void ServoTurnoutMotor::SetState(const TurnoutState desired) {
+    if( desired == this->lastState ) {
+      throw std::logic_error(__PRETTY_FUNCTION__);
+    }
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+}

--- a/src/servoturnoutmotor.cpp
+++ b/src/servoturnoutmotor.cpp
@@ -1,14 +1,13 @@
+#include "utility.hpp"
+
 #include "servoturnoutmotor.hpp"
 
 namespace Lineside {
   void ServoTurnoutMotor::OnActivate() {
-    auto servoCtrl = this->servo.lock();
-    if( servoCtrl.use_count() == 0 ) {
-      throw std::logic_error("ServoTurnoutMotor: servo pointer expired");
-    }
+    LOCK_OR_THROW( servoCtrl, this->servo );
     servoCtrl->Set(this->pwmStraight);
     this->currentState = TurnoutState::Straight;
-    this->lastState = TurnoutState::Straight;
+    this->desiredState = TurnoutState::Straight;
   }
 
   void ServoTurnoutMotor::OnDeactivate() {}
@@ -18,13 +17,11 @@ namespace Lineside {
   }
 
   bool ServoTurnoutMotor::HaveStateChange() {
-    return this->lastState != this->currentState;
+    return this->desiredState != this->currentState;
   }
 
   void ServoTurnoutMotor::SetState(const TurnoutState desired) {
-    if( desired == this->lastState ) {
-      throw std::logic_error(__PRETTY_FUNCTION__);
-    }
-    throw std::logic_error(__PRETTY_FUNCTION__);
+    this->desiredState = desired;
+    this->WakeController();
   }
 }

--- a/src/servoturnoutmotordata.cpp
+++ b/src/servoturnoutmotordata.cpp
@@ -7,7 +7,7 @@ namespace Lineside {
     curved(),
     pwmChannelRequest() {}
 
-  std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw ) {
+  std::shared_ptr<PWItemModel> ServoTurnoutMotorData::Construct( std::shared_ptr<HardwareManager> hw ) {
     if( !hw ) {
       throw std::logic_error("Bad hw ptr");
     }

--- a/src/servoturnoutmotordata.cpp
+++ b/src/servoturnoutmotordata.cpp
@@ -1,0 +1,13 @@
+#include "servoturnoutmotordata.hpp"
+
+namespace Lineside {
+  ServoTurnoutMotorData::ServoTurnoutMotorData() :
+    PWItemData(),
+    straight(),
+    curved(),
+    pwmChannelRequest() {}
+
+  std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw ) {
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+}

--- a/src/servoturnoutmotordata.cpp
+++ b/src/servoturnoutmotordata.cpp
@@ -32,7 +32,6 @@ namespace Lineside {
     auto result = std::make_shared<enabler>(this->id);
     result->pwmStraight = this->straight;
     result->pwmCurved = this->curved;
-    servo->Set(result->pwmStraight);
     result->servo = servo;
 
     return result;

--- a/src/servoturnoutmotordata.cpp
+++ b/src/servoturnoutmotordata.cpp
@@ -8,6 +8,9 @@ namespace Lineside {
     pwmChannelRequest() {}
 
   std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw ) {
+    if( !hw ) {
+      throw std::logic_error("Bad hw ptr");
+    }
     throw std::logic_error(__PRETTY_FUNCTION__);
   }
 }

--- a/src/turnoutstate.cpp
+++ b/src/turnoutstate.cpp
@@ -1,0 +1,38 @@
+#include <boost/bimap.hpp>
+
+#include "turnoutstate.hpp"
+
+namespace Lineside {
+  static boost::bimap<TurnoutState,std::string> convertor;
+
+  static void initconvertor() {
+    typedef decltype(convertor)::value_type pos;
+    convertor.insert( pos(TurnoutState::Straight, "Straight") );
+    convertor.insert( pos(TurnoutState::Curved, "Curved") );
+  }
+
+  std::ostream& operator<<( std::ostream& os, const TurnoutState s ) {
+    os << ToString( s );
+    
+    return os;
+  }
+  
+  std::string ToString( const TurnoutState s ) {
+    if( convertor.empty() ) {
+      initconvertor();
+    }
+    
+    std::string res;
+    try {
+      res = convertor.left.at(s);
+    }
+    catch( std::out_of_range& e ) {
+      std::stringstream msg;
+      msg << "Unrecognised TurnoutState: ";
+      msg << static_cast<int>(s);
+      throw std::runtime_error(msg.str());
+    }
+    
+    return res;
+  }
+}

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND srcs turnoutstatetests.cpp)
 
 list(APPEND srcs itemidtests.cpp)
 list(APPEND srcs exceptiontests.cpp)
+list(APPEND srcs utilitytests.cpp)
 list(APPEND srcs registrartests.cpp)
 list(APPEND srcs pwitemcontrollertests.cpp)
 

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -2,10 +2,12 @@ set( srcs test.cpp )
 
 list(APPEND srcs mocks/mockbip.cpp)
 list(APPEND srcs mocks/mockpwmchannel.cpp)
+list(APPEND srcs mocks/mockpwmchannelprovider.cpp)
 list(APPEND srcs mocks/mockhardwaremanager.cpp)
 
 list(APPEND srcs mockbiptests.cpp)
 list(APPEND srcs mockpwmchanneltests.cpp)
+list(APPEND srcs mockpwmchannelprovidertests.cpp)
 
 list(APPEND srcs turnoutstatetests.cpp)
 

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -9,6 +9,8 @@ list(APPEND srcs registrartests.cpp)
 list(APPEND srcs mockbiptests.cpp)
 list(APPEND srcs pwitemcontrollertests.cpp)
 
+list(APPEND srcs servoturnoutmotortests.cpp)
+
 add_executable( LinesideTest ${srcs} )
 target_include_directories(LinesideTest
   SYSTEM PRIVATE ${Boost_INCLUDE_DIRS})

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -3,6 +3,8 @@ set( srcs test.cpp )
 list(APPEND srcs mocks/mockbip.cpp)
 list(APPEND srcs mocks/mockhardwaremanager.cpp)
 
+list(APPEND srcs turnoutstatetests.cpp)
+
 list(APPEND srcs itemidtests.cpp)
 list(APPEND srcs exceptiontests.cpp)
 list(APPEND srcs registrartests.cpp)

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -1,14 +1,17 @@
 set( srcs test.cpp )
 
 list(APPEND srcs mocks/mockbip.cpp)
+list(APPEND srcs mocks/mockpwmchannel.cpp)
 list(APPEND srcs mocks/mockhardwaremanager.cpp)
+
+list(APPEND srcs mockbiptests.cpp)
+list(APPEND srcs mockpwmchanneltests.cpp)
 
 list(APPEND srcs turnoutstatetests.cpp)
 
 list(APPEND srcs itemidtests.cpp)
 list(APPEND srcs exceptiontests.cpp)
 list(APPEND srcs registrartests.cpp)
-list(APPEND srcs mockbiptests.cpp)
 list(APPEND srcs pwitemcontrollertests.cpp)
 
 list(APPEND srcs servoturnoutmotortests.cpp)

--- a/tst/exceptiontests.cpp
+++ b/tst/exceptiontests.cpp
@@ -18,6 +18,14 @@ BOOST_AUTO_TEST_CASE(ItemIdMismatchException)
   BOOST_CHECK_EQUAL(expected, ime.what());
 }
 
+BOOST_AUTO_TEST_CASE(PointerLockFailureException)
+{
+  Lineside::PointerLockFailureException plfe(__FILE__, __LINE__);
+  // The __FILE__ macro is expanding to the full path
+  BOOST_CHECK_NE( plfe.filename.find("exceptiontests.cpp"), std::string::npos );
+  BOOST_CHECK_EQUAL( plfe.linenumber, 23 );
+}
+
 BOOST_AUTO_TEST_CASE(KeyNotFoundException)
 {
   Lineside::KeyNotFoundException knfe("myKey");

--- a/tst/mockbiptests.cpp
+++ b/tst/mockbiptests.cpp
@@ -4,26 +4,13 @@
 #include <boost/test/unit_test.hpp>
 
 #include "mocks/mockbip.hpp"
+#include "notifytarget.hpp"
 
 /*
   These tests are more about validating the code in the abstract
   class BinaryOutputPin than the MockBIP itself.
  */
 
-class NotifyTarget : public Lineside::Notifiable<bool> {
-public:
-  NotifyTarget() :
-    lastNotificationSource(0),
-    lastNotification(false) {}
-  
-  unsigned int lastNotificationSource;
-  bool lastNotification;
-
-  virtual void Notify(const unsigned int sourceId, const bool notification) override {
-    this->lastNotificationSource = sourceId;
-    this->lastNotification = notification;
-  }
-};
 
 BOOST_AUTO_TEST_SUITE(MockBIPValidation)
 

--- a/tst/mockhardwaremanagerfixture.hpp
+++ b/tst/mockhardwaremanagerfixture.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <memory>
+
+#include "mocks/mockhardwaremanager.hpp"
+
+struct MockHardwareManagerFixture {
+  std::shared_ptr<MockHardwareManager> hwManager;
+
+  MockHardwareManagerFixture() :
+    hwManager(std::make_shared<MockHardwareManager>()) {}
+};

--- a/tst/mockpwmchannelprovidertests.cpp
+++ b/tst/mockpwmchannelprovidertests.cpp
@@ -1,0 +1,57 @@
+#include <boost/test/unit_test.hpp>
+
+#include "utility.hpp"
+
+#include "mocks/mockpwmchannelprovider.hpp"
+#include "exceptionmessagecheck.hpp"
+
+BOOST_AUTO_TEST_SUITE(MockPWMChannelProviderValidation)
+
+BOOST_AUTO_TEST_CASE(ConstructOne)
+{
+  MockPWMChannelProvider mcp;
+  
+  const std::string channelId = "01";
+  const std::map<std::string,std::string> settings;
+
+  auto wpc = mcp.GetHardware(channelId, settings);
+  BOOST_CHECK_EQUAL( mcp.channels.size(), 1 );
+  auto sharedFromProvider = mcp.channels.at(channelId);
+  
+  LOCK_OR_THROW( spc, wpc );
+  BOOST_CHECK_EQUAL( spc.get(), sharedFromProvider.get() );
+}
+
+BOOST_AUTO_TEST_CASE(ConstructTwo)
+{
+   MockPWMChannelProvider mcp;
+
+   const std::string ch01 = "01";
+   const std::string ch02 = "02";
+   const std::map<std::string,std::string> settings;
+
+   auto wpc1 = mcp.GetHardware(ch01, settings);
+   auto wpc2 = mcp.GetHardware(ch02, settings);
+
+   BOOST_CHECK_EQUAL( mcp.channels.size(), 2 );
+   LOCK_OR_THROW( spc1, wpc1 );
+   LOCK_OR_THROW( spc2, wpc2 );
+   BOOST_CHECK_NE( spc1.get(), spc2.get() );
+}
+
+BOOST_AUTO_TEST_CASE(NoDoubleRequest)
+{
+  MockPWMChannelProvider mcp;
+
+  const std::string chId = "01";
+  const std::map<std::string,std::string> settings;
+
+  auto wpc = mcp.GetHardware(chId, settings);
+
+  std::string msg("Key '01' already present");
+  BOOST_CHECK_EXCEPTION( mcp.GetHardware(chId, settings),
+			 Lineside::DuplicateKeyException,
+			 GetExceptionMessageChecker<Lineside::DuplicateKeyException>( msg ) );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/mockpwmchanneltests.cpp
+++ b/tst/mockpwmchanneltests.cpp
@@ -1,0 +1,54 @@
+#include <boost/test/unit_test.hpp>
+
+#include "mocks/mockpwmchannel.hpp"
+
+BOOST_AUTO_TEST_SUITE(MockPWMChannelValidation)
+
+BOOST_AUTO_TEST_CASE(ConstructAndGet)
+{
+  MockPWMChannel mp;
+
+  BOOST_CHECK_EQUAL( mp.Get(), 0 );
+  BOOST_CHECK_EQUAL( mp.updates.size(), 0 );
+}
+
+BOOST_AUTO_TEST_CASE(SingleSet)
+{
+  MockPWMChannel mp;
+
+  const unsigned int anyVal = 10;
+
+  auto timePoint = std::chrono::high_resolution_clock::now();
+  mp.Set( anyVal );
+
+  BOOST_CHECK_EQUAL( mp.Get(), anyVal );
+  BOOST_REQUIRE_EQUAL( mp.updates.size(), 1 );
+
+  auto update0 = mp.updates.at(0);
+  BOOST_CHECK_EQUAL( update0.second, anyVal );
+  BOOST_CHECK( update0.first - timePoint < std::chrono::milliseconds(1) );
+}
+
+BOOST_AUTO_TEST_CASE(DoubleSet)
+{
+  MockPWMChannel mp;
+  const unsigned int i1 = 10;
+  const unsigned int i2 = i1+3;
+
+  auto timePoint = std::chrono::high_resolution_clock::now();
+  mp.Set(i1);
+  mp.Set(i2);
+
+  BOOST_CHECK_EQUAL( mp.Get(), i2 );
+  BOOST_REQUIRE_EQUAL( mp.updates.size(), 2 );
+
+  auto update0 = mp.updates.at(0);
+  BOOST_CHECK_EQUAL( update0.second, i1 );
+  BOOST_CHECK( update0.first - timePoint < std::chrono::milliseconds(1) );
+
+  auto update1 = mp.updates.at(1);
+  BOOST_CHECK_EQUAL( update1.second, i2 );
+  BOOST_CHECK( update1.first > update0.first );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/mocks/mockhardwaremanager.cpp
+++ b/tst/mocks/mockhardwaremanager.cpp
@@ -2,14 +2,14 @@
 
 #include "mockhardwaremanager.hpp"
 
-Lineside::BOPProviderRegistrar* MockHardwareManager::GetBOPProviderRegistrar() {
+std::weak_ptr<Lineside::BOPProviderRegistrar> MockHardwareManager::GetBOPProviderRegistrar() {
   throw std::logic_error("Not yet implemented");
 }
 
-Lineside::BIPProviderRegistrar* MockHardwareManager::GetBIPProviderRegistrar() {
+std::weak_ptr<Lineside::BIPProviderRegistrar> MockHardwareManager::GetBIPProviderRegistrar() {
   throw std::logic_error("Not yet implemented");
 }
 
-Lineside::PWMCProviderRegistrar* MockHardwareManager::GetPWMCProviderRegistrar() {
+std::weak_ptr<Lineside::PWMCProviderRegistrar> MockHardwareManager::GetPWMCProviderRegistrar() {
   throw std::logic_error("Not yet implemented");
 }

--- a/tst/mocks/mockhardwaremanager.cpp
+++ b/tst/mocks/mockhardwaremanager.cpp
@@ -11,5 +11,5 @@ std::weak_ptr<Lineside::BIPProviderRegistrar> MockHardwareManager::GetBIPProvide
 }
 
 std::weak_ptr<Lineside::PWMCProviderRegistrar> MockHardwareManager::GetPWMCProviderRegistrar() {
-  throw std::logic_error("Not yet implemented");
+  return this->pwmChannelProviderRegistrar;
 }

--- a/tst/mocks/mockhardwaremanager.hpp
+++ b/tst/mocks/mockhardwaremanager.hpp
@@ -4,7 +4,7 @@
 
 class MockHardwareManager : public Lineside::HardwareManager {
 public:
-  virtual Lineside::BOPProviderRegistrar* GetBOPProviderRegistrar() override;
-  virtual Lineside::BIPProviderRegistrar* GetBIPProviderRegistrar() override;
-  virtual Lineside::PWMCProviderRegistrar* GetPWMCProviderRegistrar() override;
+  virtual std::weak_ptr<Lineside::BOPProviderRegistrar> GetBOPProviderRegistrar() override;
+  virtual std::weak_ptr<Lineside::BIPProviderRegistrar> GetBIPProviderRegistrar() override;
+  virtual std::weak_ptr<Lineside::PWMCProviderRegistrar> GetPWMCProviderRegistrar() override;
 };

--- a/tst/mocks/mockhardwaremanager.hpp
+++ b/tst/mocks/mockhardwaremanager.hpp
@@ -2,7 +2,7 @@
 
 #include "hardwaremanager.hpp"
 
-class MockHardwareManager : Lineside::HardwareManager {
+class MockHardwareManager : public Lineside::HardwareManager {
 public:
   virtual Lineside::BOPProviderRegistrar* GetBOPProviderRegistrar() override;
   virtual Lineside::BIPProviderRegistrar* GetBIPProviderRegistrar() override;

--- a/tst/mocks/mockhardwaremanager.hpp
+++ b/tst/mocks/mockhardwaremanager.hpp
@@ -2,8 +2,23 @@
 
 #include "hardwaremanager.hpp"
 
+#include "mockpwmchannelprovider.hpp"
+
 class MockHardwareManager : public Lineside::HardwareManager {
 public:
+  const std::string PWMChannelProviderId = "PWM";
+  
+  MockHardwareManager() :
+    HardwareManager(),
+    pwmChannelProvider(std::make_shared<MockPWMChannelProvider>()),
+    pwmChannelProviderRegistrar(std::make_shared<Lineside::PWMCProviderRegistrar>()) {
+    this->pwmChannelProviderRegistrar->Register( PWMChannelProviderId, this->pwmChannelProvider );
+  }
+  
+  std::shared_ptr<MockPWMChannelProvider> pwmChannelProvider;
+  
+  std::shared_ptr<Lineside::PWMCProviderRegistrar> pwmChannelProviderRegistrar;
+  
   virtual std::weak_ptr<Lineside::BOPProviderRegistrar> GetBOPProviderRegistrar() override;
   virtual std::weak_ptr<Lineside::BIPProviderRegistrar> GetBIPProviderRegistrar() override;
   virtual std::weak_ptr<Lineside::PWMCProviderRegistrar> GetPWMCProviderRegistrar() override;

--- a/tst/mocks/mockpwmchannel.cpp
+++ b/tst/mocks/mockpwmchannel.cpp
@@ -1,0 +1,11 @@
+#include "mockpwmchannel.hpp"
+
+void MockPWMChannel::Set(const unsigned int value) {
+  this->state = value;
+  auto update = std::make_pair( std::chrono::high_resolution_clock::now(), value );
+  this->updates.push_back(update);
+}
+
+unsigned int MockPWMChannel::Get() const {
+  return this->state;
+}

--- a/tst/mocks/mockpwmchannel.cpp
+++ b/tst/mocks/mockpwmchannel.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "mockpwmchannel.hpp"
 
 void MockPWMChannel::Set(const unsigned int value) {

--- a/tst/mocks/mockpwmchannel.hpp
+++ b/tst/mocks/mockpwmchannel.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <vector>
+#include <chrono>
+
+#include "pwmchannel.hpp"
+
+class MockPWMChannel : public Lineside::PWMChannel {
+public:
+  MockPWMChannel():
+    PWMChannel(),
+    updates(),
+    state(0) {}
+
+  virtual void Set(const unsigned int value) override;
+
+  virtual unsigned int Get() const override;
+
+  std::vector<std::pair<std::chrono::high_resolution_clock::time_point,unsigned int>> updates;
+private:
+  unsigned int state;
+};

--- a/tst/mocks/mockpwmchannelprovider.cpp
+++ b/tst/mocks/mockpwmchannelprovider.cpp
@@ -1,0 +1,24 @@
+#include <sstream>
+
+#include "linesideexceptions.hpp"
+
+#include "mockpwmchannelprovider.hpp"
+
+std::weak_ptr<Lineside::PWMChannel> MockPWMChannelProvider::GetHardware(const std::string& hardwareId,
+							    const std::map<std::string,std::string>& settings) {
+  if( settings.size() != 0 ) {
+    std::stringstream msg;
+    msg << "MockPWMChannel request for "
+	<< hardwareId
+	<< " did not have empty settings";
+    throw std::logic_error(msg.str());
+  }
+
+  if( this->channels.count(hardwareId) != 0 ) {
+    throw Lineside::DuplicateKeyException(hardwareId);
+  }
+  
+  auto result = std::make_shared<MockPWMChannel>();
+  this->channels[hardwareId] = result;
+  return result;
+}

--- a/tst/mocks/mockpwmchannelprovider.hpp
+++ b/tst/mocks/mockpwmchannelprovider.hpp
@@ -9,7 +9,8 @@
 class MockPWMChannelProvider : public Lineside::HardwareProvider<Lineside::PWMChannel> {
 public:
   MockPWMChannelProvider() :
-    HardwareProvider() {}
+    HardwareProvider(),
+    channels() {}
   
   virtual std::weak_ptr<Lineside::PWMChannel> GetHardware(const std::string& hardwareId,
 							  const std::map<std::string,std::string>& settings) override;

--- a/tst/mocks/mockpwmchannelprovider.hpp
+++ b/tst/mocks/mockpwmchannelprovider.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <map>
+
+#include "hardwareprovider.hpp"
+#include "pwmchannel.hpp"
+#include "mockpwmchannel.hpp"
+
+class MockPWMChannelProvider : public Lineside::HardwareProvider<Lineside::PWMChannel> {
+public:
+  MockPWMChannelProvider() :
+    HardwareProvider() {}
+  
+  virtual std::weak_ptr<Lineside::PWMChannel> GetHardware(const std::string& hardwareId,
+							  const std::map<std::string,std::string>& settings) override;
+
+  std::map<std::string,std::shared_ptr<MockPWMChannel>> channels;
+};

--- a/tst/notifytarget.hpp
+++ b/tst/notifytarget.hpp
@@ -1,0 +1,16 @@
+#include "notifiable.hpp"
+
+class NotifyTarget : public Lineside::Notifiable<bool> {
+public:
+  NotifyTarget() :
+    lastNotificationSource(0),
+    lastNotification(false) {}
+  
+  unsigned int lastNotificationSource;
+  bool lastNotification;
+
+  virtual void Notify(const unsigned int sourceId, const bool notification) override {
+    this->lastNotificationSource = sourceId;
+    this->lastNotification = notification;
+  }
+};

--- a/tst/registrartests.cpp
+++ b/tst/registrartests.cpp
@@ -11,36 +11,44 @@ BOOST_AUTO_TEST_SUITE(Registrar)
 BOOST_AUTO_TEST_CASE(RegisterAndRetrieve)
 {
   const std::string name = "Sample";
+  const int myVal = 3;
   Lineside::Registrar<int> hpr;
 
-  int myInt = 3;
+  std::shared_ptr<int> myInt = std::make_shared<int>(myVal);
+  BOOST_CHECK( myInt.unique() );
 
-  hpr.Register(name, &myInt);
-  auto res = hpr.Retrieve(name);
+  hpr.Register(name, myInt);
+  BOOST_CHECK( myInt.unique() );
+  auto res = hpr.Retrieve(name).lock();
 
-  BOOST_CHECK_EQUAL( res, &myInt );
+  BOOST_CHECK_EQUAL( res, myInt );
+  BOOST_CHECK_EQUAL( *res, myVal );
 }
 
 BOOST_AUTO_TEST_CASE(RegisterTwoAndRetrieve)
 {
   const std::string n1 = "First";
   const std::string n2 = "Second";
+  const int val1 = 3;
+  const int val2 = 4;
 
   Lineside::Registrar<int> hpr;
 
-  int i1 = 3;
-  int i2 = 4;
+  std::shared_ptr<int> i1 = std::make_shared<int>(val1);
+  std::shared_ptr<int> i2 = std::make_shared<int>(val2);
 
-  hpr.Register(n1, &i1);
-  hpr.Register(n2, &i2);
+  hpr.Register(n1, i1);
+  hpr.Register(n2, i2);
+  BOOST_CHECK( i1.unique() );
+  BOOST_CHECK( i2.unique() );
 
-  int* res1 = hpr.Retrieve(n1);
-  int* res2 = hpr.Retrieve(n2);
+  auto res1 = hpr.Retrieve(n1).lock();
+  auto res2 = hpr.Retrieve(n2).lock();
 
-  BOOST_CHECK_EQUAL( i1, *res1 );
-  BOOST_CHECK_EQUAL( i2, *res2 );
-  BOOST_CHECK_EQUAL( &i1, res1 );
-  BOOST_CHECK_EQUAL( &i2, res2 );
+  BOOST_CHECK_EQUAL( i1, res1 );
+  BOOST_CHECK_EQUAL( i2, res2 );
+  BOOST_CHECK_EQUAL( val1, *res1 );
+  BOOST_CHECK_EQUAL( val2, *res2 );
 }
 
 BOOST_AUTO_TEST_CASE(ExceptionOnMissingKey)
@@ -61,10 +69,11 @@ BOOST_AUTO_TEST_CASE(ExceptionOnDuplicateKey)
 
   const std::string name = "AnotherThing";
 
-  int i1 = 3;
+  std::shared_ptr<int> i1 = std::make_shared<int>(3);
+  std::shared_ptr<int> i2 = std::make_shared<int>(4);
 
-  hpr.Register(name, &i1);
-  BOOST_CHECK_EXCEPTION( hpr.Register(name, &i1),
+  hpr.Register(name, i1);
+  BOOST_CHECK_EXCEPTION( hpr.Register(name, i2),
 			 Lineside::DuplicateKeyException,
 			 [&](const Lineside::DuplicateKeyException& e) {
 			   return e.keyName == name;

--- a/tst/registrartests.cpp
+++ b/tst/registrartests.cpp
@@ -4,6 +4,8 @@
 
 #include "registrar.hpp"
 
+#include "utility.hpp"
+
 // ==========================================
 
 BOOST_AUTO_TEST_SUITE(Registrar)
@@ -19,7 +21,7 @@ BOOST_AUTO_TEST_CASE(RegisterAndRetrieve)
 
   hpr.Register(name, myInt);
   BOOST_CHECK( myInt.unique() );
-  auto res = hpr.Retrieve(name).lock();
+  LOCK_OR_THROW( res, hpr.Retrieve(name) );
 
   BOOST_CHECK_EQUAL( res, myInt );
   BOOST_CHECK_EQUAL( *res, myVal );
@@ -42,8 +44,8 @@ BOOST_AUTO_TEST_CASE(RegisterTwoAndRetrieve)
   BOOST_CHECK( i1.unique() );
   BOOST_CHECK( i2.unique() );
 
-  auto res1 = hpr.Retrieve(n1).lock();
-  auto res2 = hpr.Retrieve(n2).lock();
+  LOCK_OR_THROW( res1, hpr.Retrieve(n1) );
+  LOCK_OR_THROW( res2, hpr.Retrieve(n2) );
 
   BOOST_CHECK_EQUAL( i1, res1 );
   BOOST_CHECK_EQUAL( i2, res2 );

--- a/tst/servoturnoutmotortests.cpp
+++ b/tst/servoturnoutmotortests.cpp
@@ -164,7 +164,8 @@ BOOST_AUTO_TEST_CASE(SetCurvedAndStraight)
 
   // Check we took an appropriate time
   BOOST_CHECK_EQUAL( stm->MoveSteps, 10 );
-  BOOST_CHECK( stop-start >= stm->MoveSleep*stm->MoveSteps );
+  // We move to MoveSteps positions, so there are MoveSteps-1 intervals
+  BOOST_CHECK( stop-start >= stm->MoveSleep*(stm->MoveSteps-1) );
   // Check that the correct sleep was requested
   BOOST_CHECK( requestedSleep == stm->SleepInterval );
 
@@ -177,6 +178,8 @@ BOOST_AUTO_TEST_CASE(SetCurvedAndStraight)
     BOOST_CHECK( curr.first - prev.first >= stm->MoveSleep );
     // Since curved > straight above...
     BOOST_CHECK_GT( curr.second, prev.second );
+    BOOST_CHECK_GE( prev.second, straight );
+    BOOST_CHECK_LE( prev.second, curved );
   }
 
   // Now, repeat everything to go back to straight
@@ -189,7 +192,7 @@ BOOST_AUTO_TEST_CASE(SetCurvedAndStraight)
 
   BOOST_CHECK_EQUAL( pwmChannel->Get(), straight );
   BOOST_CHECK_EQUAL( stm->GetState(), Lineside::TurnoutState::Straight );
-  BOOST_CHECK( stop-start >= stm->MoveSleep*stm->MoveSteps );
+  BOOST_CHECK( stop-start >= stm->MoveSleep*(stm->MoveSteps-1) );
   BOOST_CHECK( requestedSleep == stm->SleepInterval );
   
   BOOST_REQUIRE_EQUAL( pwmChannel->updates.size(), stm->MoveSteps );
@@ -199,6 +202,8 @@ BOOST_AUTO_TEST_CASE(SetCurvedAndStraight)
     BOOST_CHECK( curr.first - prev.first >= stm->MoveSleep );
     // Since curved > straight above...
     BOOST_CHECK_LT( curr.second, prev.second );
+    BOOST_CHECK_GE( prev.second, straight );
+    BOOST_CHECK_LE( prev.second, curved );
   }
 }
 

--- a/tst/servoturnoutmotortests.cpp
+++ b/tst/servoturnoutmotortests.cpp
@@ -1,0 +1,25 @@
+#include <boost/test/unit_test.hpp>
+
+#include "servoturnoutmotordata.hpp"
+#include "servoturnoutmotor.hpp"
+
+
+BOOST_AUTO_TEST_SUITE(ServoTurnoutMotor)
+
+BOOST_AUTO_TEST_CASE(Construct)
+{
+  const Lineside::ItemId id(10);
+  const unsigned int straight = 10;
+  const unsigned int curved = 113;
+  const std::string controller = "MockPWMController";
+  const std::string controllerData = "07";
+  
+  Lineside::ServoTurnoutMotorData stmd;
+  stmd.id = id;
+  stmd.straight = straight;
+  stmd.curved = curved;
+  stmd.pwmChannelRequest.controller = controller;
+  stmd.pwmChannelRequest.controllerData = controllerData;
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/servoturnoutmotortests.cpp
+++ b/tst/servoturnoutmotortests.cpp
@@ -118,4 +118,88 @@ BOOST_AUTO_TEST_CASE(SetStateAndStateChange)
   BOOST_CHECK(!pwItem->HaveStateChange());
 }
 
+BOOST_AUTO_TEST_CASE(SetCurvedAndStraight)
+{
+  const unsigned int notifySrcId = 1235;
+  std::shared_ptr<NotifyTarget> nt = std::make_shared<NotifyTarget>();
+  
+  const Lineside::ItemId id(10);
+  const unsigned int straight = 10;
+  const unsigned int curved = 113;
+  const std::string controller = "MockPWMController";
+  const std::string controllerData = "07";
+  
+  Lineside::ServoTurnoutMotorData stmd;
+  stmd.id = id;
+  stmd.straight = straight;
+  stmd.curved = curved;
+  stmd.pwmChannelRequest.controller = this->hwManager->PWMChannelProviderId;
+  stmd.pwmChannelRequest.controllerData = controllerData;
+
+  auto pwItem = stmd.Construct(this->hwManager);
+  pwItem->RegisterController(notifySrcId, nt);
+  BOOST_REQUIRE( pwItem );
+  BOOST_CHECK_EQUAL( pwItem->getId(), id );
+  auto stm = std::dynamic_pointer_cast<Lineside::ServoTurnoutMotor>(pwItem);
+  BOOST_REQUIRE( stm );
+  auto pwmChannel = this->hwManager->pwmChannelProvider->channels.at(controllerData);
+  BOOST_REQUIRE( pwmChannel );
+
+  // Call the onActivate method
+  pwItem->OnActivate();
+
+  // Clear the pwmChannel updates
+  pwmChannel->updates.clear();
+
+  // Indicate that we want to change state to Curved
+  stm->SetState(Lineside::TurnoutState::Curved);
+
+  auto start = std::chrono::high_resolution_clock::now();
+  auto requestedSleep = stm->OnRun();
+  auto stop = std::chrono::high_resolution_clock::now();
+
+  // Check we got to the right place
+  BOOST_CHECK_EQUAL( pwmChannel->Get(), curved );
+  BOOST_CHECK_EQUAL( stm->GetState(), Lineside::TurnoutState::Curved );
+
+  // Check we took an appropriate time
+  BOOST_CHECK_EQUAL( stm->MoveSteps, 10 );
+  BOOST_CHECK( stop-start >= stm->MoveSleep*stm->MoveSteps );
+  // Check that the correct sleep was requested
+  BOOST_CHECK( requestedSleep == stm->SleepInterval );
+
+  // Now examine the set of updates to the pwmChannel
+  BOOST_REQUIRE_EQUAL( pwmChannel->updates.size(), stm->MoveSteps );
+
+  for( size_t i=1; i<pwmChannel->updates.size(); i++ ) {
+    auto prev = pwmChannel->updates.at(i-1);
+    auto curr = pwmChannel->updates.at(i);
+    BOOST_CHECK( curr.first - prev.first >= stm->MoveSleep );
+    // Since curved > straight above...
+    BOOST_CHECK_GT( curr.second, prev.second );
+  }
+
+  // Now, repeat everything to go back to straight
+
+  pwmChannel->updates.clear();
+  stm->SetState(Lineside::TurnoutState::Straight);
+  start = std::chrono::high_resolution_clock::now();
+  requestedSleep = stm->OnRun();
+  stop = std::chrono::high_resolution_clock::now();
+
+  BOOST_CHECK_EQUAL( pwmChannel->Get(), straight );
+  BOOST_CHECK_EQUAL( stm->GetState(), Lineside::TurnoutState::Straight );
+  BOOST_CHECK( stop-start >= stm->MoveSleep*stm->MoveSteps );
+  BOOST_CHECK( requestedSleep == stm->SleepInterval );
+  
+  BOOST_REQUIRE_EQUAL( pwmChannel->updates.size(), stm->MoveSteps );
+  for( size_t i=1; i<pwmChannel->updates.size(); i++ ) {
+    auto prev = pwmChannel->updates.at(i-1);
+    auto curr = pwmChannel->updates.at(i);
+    BOOST_CHECK( curr.first - prev.first >= stm->MoveSleep );
+    // Since curved > straight above...
+    BOOST_CHECK_LT( curr.second, prev.second );
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/servoturnoutmotortests.cpp
+++ b/tst/servoturnoutmotortests.cpp
@@ -3,8 +3,9 @@
 #include "servoturnoutmotordata.hpp"
 #include "servoturnoutmotor.hpp"
 
+#include "mockhardwaremanagerfixture.hpp"
 
-BOOST_AUTO_TEST_SUITE(ServoTurnoutMotor)
+BOOST_FIXTURE_TEST_SUITE(ServoTurnoutMotor, MockHardwareManagerFixture)
 
 BOOST_AUTO_TEST_CASE(Construct)
 {
@@ -20,6 +21,14 @@ BOOST_AUTO_TEST_CASE(Construct)
   stmd.curved = curved;
   stmd.pwmChannelRequest.controller = controller;
   stmd.pwmChannelRequest.controllerData = controllerData;
+
+  auto pwItem = stmd.Construct(this->hwManager);
+  BOOST_REQUIRE( pwItem );
+  auto stm = std::dynamic_pointer_cast<Lineside::ServoTurnoutMotor>(pwItem);
+  BOOST_REQUIRE( stm );
+  BOOST_REQUIRE_GT( stm.use_count(), 0 );
+
+  BOOST_CHECK_EQUAL( stm->getState(), Lineside::TurnoutState::Straight );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/servoturnoutmotortests.cpp
+++ b/tst/servoturnoutmotortests.cpp
@@ -19,16 +19,44 @@ BOOST_AUTO_TEST_CASE(Construct)
   stmd.id = id;
   stmd.straight = straight;
   stmd.curved = curved;
-  stmd.pwmChannelRequest.controller = controller;
+  stmd.pwmChannelRequest.controller = this->hwManager->PWMChannelProviderId;
   stmd.pwmChannelRequest.controllerData = controllerData;
 
   auto pwItem = stmd.Construct(this->hwManager);
   BOOST_REQUIRE( pwItem );
+  BOOST_CHECK_EQUAL( pwItem->getId(), id );
   auto stm = std::dynamic_pointer_cast<Lineside::ServoTurnoutMotor>(pwItem);
   BOOST_REQUIRE( stm );
-  BOOST_REQUIRE_GT( stm.use_count(), 0 );
+  BOOST_REQUIRE_EQUAL( stm.use_count(), 2 ); // pwItem and stm itself
 
   BOOST_CHECK_EQUAL( stm->getState(), Lineside::TurnoutState::Straight );
+  auto pwmChannel = this->hwManager->pwmChannelProvider->channels.at(controllerData);
+  BOOST_CHECK_EQUAL( pwmChannel->Get(), straight );
+}
+
+BOOST_AUTO_TEST_CASE(SetCurved)
+{
+  const Lineside::ItemId id(10);
+  const unsigned int straight = 10;
+  const unsigned int curved = 113;
+  const std::string controller = "MockPWMController";
+  const std::string controllerData = "07";
+  
+  Lineside::ServoTurnoutMotorData stmd;
+  stmd.id = id;
+  stmd.straight = straight;
+  stmd.curved = curved;
+  stmd.pwmChannelRequest.controller = this->hwManager->PWMChannelProviderId;
+  stmd.pwmChannelRequest.controllerData = controllerData;
+
+  auto pwItem = stmd.Construct(this->hwManager);
+  BOOST_REQUIRE( pwItem );
+  BOOST_CHECK_EQUAL( pwItem->getId(), id );
+  auto stm = std::dynamic_pointer_cast<Lineside::ServoTurnoutMotor>(pwItem);
+  BOOST_REQUIRE( stm );
+  BOOST_REQUIRE_EQUAL( stm.use_count(), 2 );
+
+  BOOST_FAIL("Need to implement the rest");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/servoturnoutmotortests.cpp
+++ b/tst/servoturnoutmotortests.cpp
@@ -3,6 +3,7 @@
 #include "servoturnoutmotordata.hpp"
 #include "servoturnoutmotor.hpp"
 
+#include "notifytarget.hpp"
 #include "mockhardwaremanagerfixture.hpp"
 
 BOOST_FIXTURE_TEST_SUITE(ServoTurnoutMotor, MockHardwareManagerFixture)
@@ -28,13 +29,9 @@ BOOST_AUTO_TEST_CASE(Construct)
   auto stm = std::dynamic_pointer_cast<Lineside::ServoTurnoutMotor>(pwItem);
   BOOST_REQUIRE( stm );
   BOOST_REQUIRE_EQUAL( stm.use_count(), 2 ); // pwItem and stm itself
-
-  BOOST_CHECK_EQUAL( stm->getState(), Lineside::TurnoutState::Straight );
-  auto pwmChannel = this->hwManager->pwmChannelProvider->channels.at(controllerData);
-  BOOST_CHECK_EQUAL( pwmChannel->Get(), straight );
 }
 
-BOOST_AUTO_TEST_CASE(SetCurved)
+BOOST_AUTO_TEST_CASE(OnActivateSetsStraight)
 {
   const Lineside::ItemId id(10);
   const unsigned int straight = 10;
@@ -54,9 +51,71 @@ BOOST_AUTO_TEST_CASE(SetCurved)
   BOOST_CHECK_EQUAL( pwItem->getId(), id );
   auto stm = std::dynamic_pointer_cast<Lineside::ServoTurnoutMotor>(pwItem);
   BOOST_REQUIRE( stm );
-  BOOST_REQUIRE_EQUAL( stm.use_count(), 2 );
 
-  BOOST_FAIL("Need to implement the rest");
+  // Call the onActivate method
+  pwItem->OnActivate();
+  
+  BOOST_CHECK_EQUAL( stm->GetState(), Lineside::TurnoutState::Straight );
+  auto pwmChannel = this->hwManager->pwmChannelProvider->channels.at(controllerData);
+  BOOST_CHECK_EQUAL( pwmChannel->Get(), straight );
+}
+
+BOOST_AUTO_TEST_CASE(SetStateAndStateChange)
+{
+  const unsigned int notifySrcId = 1235;
+  std::shared_ptr<NotifyTarget> nt = std::make_shared<NotifyTarget>();
+  
+  const Lineside::ItemId id(10);
+  const unsigned int straight = 10;
+  const unsigned int curved = 113;
+  const std::string controller = "MockPWMController";
+  const std::string controllerData = "07";
+  
+  Lineside::ServoTurnoutMotorData stmd;
+  stmd.id = id;
+  stmd.straight = straight;
+  stmd.curved = curved;
+  stmd.pwmChannelRequest.controller = this->hwManager->PWMChannelProviderId;
+  stmd.pwmChannelRequest.controllerData = controllerData;
+
+  auto pwItem = stmd.Construct(this->hwManager);
+  pwItem->RegisterController(notifySrcId, nt);
+  BOOST_REQUIRE( pwItem );
+  BOOST_CHECK_EQUAL( pwItem->getId(), id );
+  auto stm = std::dynamic_pointer_cast<Lineside::ServoTurnoutMotor>(pwItem);
+  BOOST_REQUIRE( stm );
+
+  // Call the onActivate method
+  pwItem->OnActivate();
+
+  // Things should be consistent now
+  BOOST_CHECK(!pwItem->HaveStateChange());
+
+  // Change the desired state
+  nt->lastNotificationSource = 0;
+  nt->lastNotification = false;
+  stm->SetState(Lineside::TurnoutState::Curved);
+  BOOST_CHECK_EQUAL( nt->lastNotificationSource, notifySrcId );
+  BOOST_CHECK_EQUAL( nt->lastNotification, true );
+  // However, the actual state never changed
+  auto pwmChannel = this->hwManager->pwmChannelProvider->channels.at(controllerData);
+  BOOST_CHECK_EQUAL( stm->GetState(), Lineside::TurnoutState::Straight );
+  BOOST_CHECK_EQUAL( pwmChannel->Get(), straight );
+  
+  // Check that we're indicating an update
+  BOOST_CHECK(pwItem->HaveStateChange());
+
+  // Go back to straight
+  nt->lastNotificationSource = 0;
+  nt->lastNotification = false;
+  stm->SetState(Lineside::TurnoutState::Straight);
+  BOOST_CHECK_EQUAL( nt->lastNotificationSource, notifySrcId );
+  BOOST_CHECK_EQUAL( nt->lastNotification, true );
+
+  // Since the actual internal currentState never changed...
+  BOOST_CHECK_EQUAL( stm->GetState(), Lineside::TurnoutState::Straight );
+  BOOST_CHECK_EQUAL( pwmChannel->Get(), straight );
+  BOOST_CHECK(!pwItem->HaveStateChange());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/turnoutstatetests.cpp
+++ b/tst/turnoutstatetests.cpp
@@ -1,0 +1,37 @@
+#include <boost/test/unit_test.hpp>
+
+#include "turnoutstate.hpp"
+
+BOOST_AUTO_TEST_SUITE( TurnoutState )
+
+BOOST_AUTO_TEST_CASE( ToString )
+{
+  Lineside::TurnoutState ts;
+  std::string res;
+
+  ts = Lineside::TurnoutState::Straight;
+  res = Lineside::ToString( ts );
+  BOOST_CHECK_EQUAL(res, "Straight");
+
+  ts = Lineside::TurnoutState::Curved;
+  res = Lineside::ToString( ts );
+  BOOST_CHECK_EQUAL( res, "Curved" );
+}
+
+BOOST_AUTO_TEST_CASE( StreamInsertion )
+{
+  Lineside::TurnoutState ts;
+  std::stringstream res;
+
+  ts = Lineside::TurnoutState::Straight;
+  res << ts;
+  BOOST_CHECK_EQUAL( res.str(), "Straight" );
+  res.str(std::string()); // Empty the stream
+
+  ts = Lineside::TurnoutState::Curved;
+  res << ts;
+  BOOST_CHECK_EQUAL( res.str(), "Curved" );
+  res.str(std::string());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/utilitytests.cpp
+++ b/tst/utilitytests.cpp
@@ -1,0 +1,58 @@
+#include <boost/test/unit_test.hpp>
+
+#include "utility.hpp"
+
+BOOST_AUTO_TEST_SUITE(Utility)
+
+BOOST_AUTO_TEST_SUITE(Lock_Or_Throw)
+
+BOOST_AUTO_TEST_CASE(Successful)
+{
+  const int anyInt = 10;
+  auto myInt = std::make_shared<int>(anyInt);
+
+  BOOST_CHECK( myInt );
+  BOOST_CHECK_EQUAL( *myInt, anyInt );
+  BOOST_CHECK_EQUAL( myInt.use_count(), 1 );
+
+  auto wp = std::weak_ptr<int>(myInt);
+  BOOST_CHECK_EQUAL( wp.use_count(), 1 );
+
+  LOCK_OR_THROW( sp, wp );
+
+  BOOST_CHECK_EQUAL( myInt.use_count(), 2 );
+  BOOST_CHECK_EQUAL( wp.use_count(), 2 );
+  BOOST_CHECK_EQUAL( *sp, *myInt );
+  BOOST_CHECK_EQUAL( sp.get(), myInt.get() );
+}
+
+BOOST_AUTO_TEST_CASE(Failure)
+{
+  auto wp = std::weak_ptr<int>();
+  BOOST_CHECK( wp.expired() );
+
+  {
+    const int anyInt = 10;
+    auto myInt = std::make_shared<int>(anyInt);
+
+    wp = myInt;
+    BOOST_CHECK( !wp.expired() );
+    BOOST_CHECK_EQUAL( wp.use_count(), 1 );
+  }
+
+  BOOST_CHECK( wp.expired() );
+
+  BOOST_CHECK_EXCEPTION( LOCK_OR_THROW( sp, wp ),
+			 Lineside::PointerLockFailureException,
+			 [&](const Lineside::PointerLockFailureException& e) {
+			   BOOST_CHECK_EQUAL( e.linenumber, 45 );
+			   BOOST_CHECK_NE( e.filename.find("utilitytests.cpp"),
+					   std::string::npos );
+
+			   return true;
+			 } );
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/utilitytests.cpp
+++ b/tst/utilitytests.cpp
@@ -1,3 +1,5 @@
+#include <set>
+
 #include <boost/test/unit_test.hpp>
 
 #include "utility.hpp"
@@ -45,7 +47,13 @@ BOOST_AUTO_TEST_CASE(Failure)
   BOOST_CHECK_EXCEPTION( LOCK_OR_THROW( sp, wp ),
 			 Lineside::PointerLockFailureException,
 			 [&](const Lineside::PointerLockFailureException& e) {
-			   BOOST_CHECK_EQUAL( e.linenumber, 45 );
+			   /* 
+			      The exact line number in the exception can vary with compiler.
+			      It appears that Clang picks the first line of the
+			      BOOST_CHECK_EXCEPTION statement while gcc picks the last
+			   */
+			   std::set<unsigned int> possibleLines({ 47, 54 });
+			   BOOST_CHECK_EQUAL( possibleLines.count(e.linenumber), 1 );
 			   BOOST_CHECK_NE( e.filename.find("utilitytests.cpp"),
 					   std::string::npos );
 

--- a/tst/utilitytests.cpp
+++ b/tst/utilitytests.cpp
@@ -52,8 +52,10 @@ BOOST_AUTO_TEST_CASE(Failure)
 			      It appears that Clang picks the first line of the
 			      BOOST_CHECK_EXCEPTION statement while gcc picks the last
 			   */
-			   std::set<unsigned int> possibleLines({ 47, 54 });
+			   std::set<unsigned int> possibleLines({ 47, 64 });
+			   BOOST_TEST_INFO("Reported line number " << e.linenumber );
 			   BOOST_CHECK_EQUAL( possibleLines.count(e.linenumber), 1 );
+			   BOOST_TEST_INFO("Reported filename " << e.filename );
 			   BOOST_CHECK_NE( e.filename.find("utilitytests.cpp"),
 					   std::string::npos );
 

--- a/tst/utilitytests.cpp
+++ b/tst/utilitytests.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(Failure)
 			      It appears that Clang picks the first line of the
 			      BOOST_CHECK_EXCEPTION statement while gcc picks the last
 			   */
-			   std::set<unsigned int> possibleLines({ 47, 64 });
+			   std::set<unsigned int> possibleLines({ 47, 63 });
 			   BOOST_TEST_INFO("Reported line number " << e.linenumber );
 			   BOOST_CHECK_EQUAL( possibleLines.count(e.linenumber), 1 );
 			   BOOST_TEST_INFO("Reported filename " << e.filename );


### PR DESCRIPTION
Add an implementation of a `PWItemModel` for servo turnouts. This consists of:
- A `ServoTurnoutMotor` class
- A `ServoTurnoutMotorData` class
- Tests of the basic functionality

A number of other changes have been made in support of these, including augmented mocks and a `LOCK_OR_THROW` macro for turning `std::weak_ptr`s into `std::shared_ptr`s .