### PR TITLE
Add mock for BinaryOutputPin

### DIFF
--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -3,6 +3,7 @@ set( srcs test.cpp )
 list(APPEND srcs mocks/mockbip.cpp)
 list(APPEND srcs mocks/mockpwmchannel.cpp)
 list(APPEND srcs mocks/mockpwmchannelprovider.cpp)
+list(APPEND srcs mocks/mockbopprovider.cpp)
 list(APPEND srcs mocks/mockhardwaremanager.cpp)
 
 list(APPEND srcs mockbiptests.cpp)

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -9,6 +9,7 @@ list(APPEND srcs mocks/mockhardwaremanager.cpp)
 list(APPEND srcs mockbiptests.cpp)
 list(APPEND srcs mockpwmchanneltests.cpp)
 list(APPEND srcs mockpwmchannelprovidertests.cpp)
+list(APPEND srcs mockbopprovidertests.cpp)
 
 list(APPEND srcs turnoutstatetests.cpp)
 

--- a/tst/mockbopprovidertests.cpp
+++ b/tst/mockbopprovidertests.cpp
@@ -1,0 +1,26 @@
+#include <boost/test/unit_test.hpp>
+
+#include "utility.hpp"
+
+#include "mocks/mockbopprovider.hpp"
+#include "exceptionmessagecheck.hpp"
+
+BOOST_AUTO_TEST_SUITE(MockBOPProviderValidation)
+
+BOOST_AUTO_TEST_CASE(ConstructOne)
+{
+  MockBOPProvider mbb;
+  BOOST_CHECK_EQUAL( mbb.pins.size(), 0 );
+
+  const std::string channelId = "01";
+  const std::map<std::string,std::string> settings;
+
+  auto wbop = mbb.GetHardware(channelId, settings);
+  BOOST_CHECK_EQUAL( mbb.pins.size(), 1 );
+  auto sharedFromProvider = mbb.pins.at(channelId);
+
+  LOCK_OR_THROW( sbop, wbop );
+  BOOST_CHECK_EQUAL( sbop.get(), sharedFromProvider.get() );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/mockbopprovidertests.cpp
+++ b/tst/mockbopprovidertests.cpp
@@ -23,4 +23,38 @@ BOOST_AUTO_TEST_CASE(ConstructOne)
   BOOST_CHECK_EQUAL( sbop.get(), sharedFromProvider.get() );
 }
 
+BOOST_AUTO_TEST_CASE(ConstructTwo)
+{
+  MockBOPProvider mbb;
+  BOOST_CHECK_EQUAL( mbb.pins.size(), 0 );
+
+  const std::string ch01 = "01";
+  const std::string ch02 = "012";
+  const std::map<std::string,std::string> settings;
+
+  auto wbop1 = mbb.GetHardware(ch01, settings);
+  auto wbop2 = mbb.GetHardware(ch02, settings);
+
+  BOOST_CHECK_EQUAL( mbb.pins.size(), 2 );
+  LOCK_OR_THROW( sbop1, wbop1 );
+  LOCK_OR_THROW( sbop2, wbop2 );
+  BOOST_CHECK_NE( sbop1.get(), sbop2.get() );
+}
+
+BOOST_AUTO_TEST_CASE(NoDoubleRequest)
+{
+  MockBOPProvider mbb;
+  BOOST_CHECK_EQUAL( mbb.pins.size(), 0 );
+  
+  const std::string chId = "01";
+  const std::map<std::string,std::string> settings;
+
+  auto wpc = mbb.GetHardware(chId, settings);
+
+  std::string msg("Key '01' already present");
+  BOOST_CHECK_EXCEPTION( mbb.GetHardware(chId, settings),
+			 Lineside::DuplicateKeyException,
+			 GetExceptionMessageChecker<Lineside::DuplicateKeyException>(msg) );
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/mocks/mockbop.hpp
+++ b/tst/mocks/mockbop.hpp
@@ -2,7 +2,7 @@
 
 #include "binaryoutputpin.hpp"
 
-class MockBOP : public Lineside::BinaryInputPin {
+class MockBOP : public Lineside::BinaryOutputPin {
 public:
   MockBOP() :
     BinaryOutputPin(),

--- a/tst/mocks/mockbop.hpp
+++ b/tst/mocks/mockbop.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "binaryoutputpin.hpp"
+
+class MockBOP : public Lineside::BinaryInputPin {
+public:
+  MockBOP() :
+    BinaryOutputPin(),
+    state(false) {}
+  
+  virtual void Set(const bool level) override {
+    this->state = level;
+  }
+
+  virtual bool Get() const override {
+    return this->state;
+  }
+  
+  bool state;
+};

--- a/tst/mocks/mockbopprovider.cpp
+++ b/tst/mocks/mockbopprovider.cpp
@@ -1,0 +1,8 @@
+#include "linesideexceptions.hpp"
+
+#include "mockbopprovider.hpp"
+
+std::weak_ptr<Lineside::BinaryOutputPin> MockBOPProvider::GetHardware(const std::string& hardwareId,
+								      const std::map<std::string,std::string>& settings) {
+  
+}

--- a/tst/mocks/mockbopprovider.cpp
+++ b/tst/mocks/mockbopprovider.cpp
@@ -4,5 +4,19 @@
 
 std::weak_ptr<Lineside::BinaryOutputPin> MockBOPProvider::GetHardware(const std::string& hardwareId,
 								      const std::map<std::string,std::string>& settings) {
-  
+  if( settings.size() != 0 ) {
+    std::stringstream msg;
+    msg << "MockBOP request for "
+	<< hardwareId
+	<< " did not have empty settings";
+    throw std::logic_error(msg.str());
+  }
+
+  if( this->pins.count(hardwareId) != 0 ) {
+    throw Lineside::DuplicateKeyException(hardwareId);
+  }
+
+  auto result = std::make_shared<MockBOP>();
+  this->pins[hardwareId] = result;
+  return result;
 }

--- a/tst/mocks/mockbopprovider.hpp
+++ b/tst/mocks/mockbopprovider.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <map>
+
+#include "hardwareprovider.hpp"
+#include "binaryoutputpin.hpp"
+#include "mockbop.hpp"
+
+class MockBOPProvider : public Lineside::HardwareProvider<Lineside::BinaryOutputPin> {
+public:
+  MockBOPProvider() :
+    HardwareProvider(),
+    pins() {}
+
+  virtual std::weak_ptr<Lineside::BinaryOutputPin> GetHardware(const std::string& hardwareId,
+							       const std::map<std::string,std::string>& settings) override;
+
+  std::map<std::string,std::shared_ptr<MockBOP>> pins;
+};

--- a/tst/mocks/mockhardwaremanager.cpp
+++ b/tst/mocks/mockhardwaremanager.cpp
@@ -3,7 +3,7 @@
 #include "mockhardwaremanager.hpp"
 
 std::weak_ptr<Lineside::BOPProviderRegistrar> MockHardwareManager::GetBOPProviderRegistrar() {
-  throw std::logic_error("Not yet implemented");
+  return this->bopProviderRegistrar;
 }
 
 std::weak_ptr<Lineside::BIPProviderRegistrar> MockHardwareManager::GetBIPProviderRegistrar() {

--- a/tst/mocks/mockhardwaremanager.hpp
+++ b/tst/mocks/mockhardwaremanager.hpp
@@ -2,21 +2,28 @@
 
 #include "hardwaremanager.hpp"
 
+#include "mockbopprovider.hpp"
 #include "mockpwmchannelprovider.hpp"
 
 class MockHardwareManager : public Lineside::HardwareManager {
 public:
+  const std::string BOPProviderId = "BOP";
   const std::string PWMChannelProviderId = "PWM";
   
   MockHardwareManager() :
     HardwareManager(),
+    bopProvider(std::make_shared<MockBOPProvider>()),
     pwmChannelProvider(std::make_shared<MockPWMChannelProvider>()),
+    bopProviderRegistrar(std::make_shared<Lineside::BOPProviderRegistrar>()),
     pwmChannelProviderRegistrar(std::make_shared<Lineside::PWMCProviderRegistrar>()) {
+    this->bopProviderRegistrar->Register( BOPProviderId, this->bopProvider );
     this->pwmChannelProviderRegistrar->Register( PWMChannelProviderId, this->pwmChannelProvider );
   }
-  
+
+  std::shared_ptr<MockBOPProvider> bopProvider;
   std::shared_ptr<MockPWMChannelProvider> pwmChannelProvider;
-  
+
+  std::shared_ptr<Lineside::BOPProviderRegistrar> bopProviderRegistrar;
   std::shared_ptr<Lineside::PWMCProviderRegistrar> pwmChannelProviderRegistrar;
   
   virtual std::weak_ptr<Lineside::BOPProviderRegistrar> GetBOPProviderRegistrar() override;


### PR DESCRIPTION
Adds a mock implementation of `BinaryOutputPin` with associated provider and hook into the `MockHardwareManager`. The associated `MockBOPProvider` has some basic tests as well.