### PR TITLE
Data class for multiple aspect signal heads

### DIFF
--- a/include/linesideexceptions.hpp
+++ b/include/linesideexceptions.hpp
@@ -64,6 +64,27 @@ namespace Lineside {
     }
   };
 
+  //! Exception for bad PWItem data
+  class BadPWItemDataException : public LinesideException {
+  public:
+    explicit BadPWItemDataException(const ItemId target, const std::string info) :
+      LinesideException(""),
+      item(target),
+      message() {
+      std::stringstream tmp;
+      tmp << "Configuration problem for " << this->item;
+      tmp << " - " << info;
+      this->message = tmp.str();
+    }
+    
+    const ItemId item;
+    std::string message;
+
+    virtual const char* what() const noexcept override {
+      return this->message.c_str();
+    }
+  };
+
   // ========================================
 
   //! Base exception for problems with maps

--- a/include/multiaspectsignalheaddata.hpp
+++ b/include/multiaspectsignalheaddata.hpp
@@ -7,13 +7,15 @@
 #include "signalaspect.hpp"
 
 namespace Lineside {
+  //! Class for configuration data for multiple aspect signal heads
   class MultiAspectSignalHeadData : public PWItemData {
   public:
     MultiAspectSignalHeadData();
 
     std::map<SignalAspect,DeviceRequestData> aspectRequests;
     std::map<unsigned int,DeviceRequestData> featherRequests;
-    
+
+    //! Perform some basic sanity checks
     void CheckData() const;
     
     virtual std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw ) override;

--- a/include/multiaspectsignalheaddata.hpp
+++ b/include/multiaspectsignalheaddata.hpp
@@ -8,6 +8,7 @@
 
 namespace Lineside {
   class MultiAspectSignalHeadData : public PWItemData {
+  public:
     MultiAspectSignalHeadData();
 
     std::map<SignalAspect,DeviceRequestData> aspectRequests;

--- a/include/multiaspectsignalheaddata.hpp
+++ b/include/multiaspectsignalheaddata.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <map>
+
+#include "pwitemdata.hpp"
+#include "devicerequestdata.hpp"
+#include "signalaspect.hpp"
+
+namespace Lineside {
+  class MultiAspectSignalHeadData : public PWItemData {
+    MultiAspectSignalHeadData();
+
+    std::map<SignalAspect,DeviceRequestData> aspectRequests;
+    std::map<unsigned int,DeviceRequestData> featherRequests;
+    
+    void CheckData() const;
+    
+    virtual std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw ) override;
+  };
+}

--- a/include/pwitemdata.hpp
+++ b/include/pwitemdata.hpp
@@ -7,6 +7,7 @@
 #include "hardwaremanager.hpp"
 
 namespace Lineside {
+  //! Abstract base class for configuration data for permanent way items
   class PWItemData {
   public:
     PWItemData() : id(0) {}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,8 @@ list(APPEND srcs pwitemcontroller.cpp)
 list(APPEND srcs servoturnoutmotordata.cpp)
 list(APPEND srcs servoturnoutmotor.cpp)
 
+list(APPEND srcs multiaspectsignalheaddata.cpp)
+
 add_library( lineside ${srcs} )
 target_include_directories(lineside
   PUBLIC ${PROJECT_SOURCE_DIR}/include)

--- a/src/multiaspectsignalheaddata.cpp
+++ b/src/multiaspectsignalheaddata.cpp
@@ -23,6 +23,24 @@ namespace Lineside {
 	throw BadPWItemDataException(this->id, msg);
       }
     }
+
+    if( this->featherRequests.size() > 0 ) {
+      if( this->featherRequests.count(0) != 0 ) {
+	std::string msg("Feather '0' defined");
+	throw BadPWItemDataException(this->id, msg);
+      }
+
+      unsigned int curr = 1;
+      for( auto it=this->featherRequests.begin();
+	   it!=this->featherRequests.end();
+	   ++it ) {
+	if( it->first != curr ) {
+	  std::string msg("Feathers are not sequential from one");
+	  throw BadPWItemDataException(this->id, msg);
+	}
+	curr++;
+      }
+    }
   }
 
   std::shared_ptr<PWItemModel> MultiAspectSignalHeadData::Construct( std::shared_ptr<HardwareManager> hw ) {

--- a/src/multiaspectsignalheaddata.cpp
+++ b/src/multiaspectsignalheaddata.cpp
@@ -47,6 +47,9 @@ namespace Lineside {
     if( !hw ) {
       throw std::logic_error("Bad hw ptr");
     }
+
+    this->CheckData();
+    
     throw std::logic_error(__PRETTY_FUNCTION__);
   }
 }

--- a/src/multiaspectsignalheaddata.cpp
+++ b/src/multiaspectsignalheaddata.cpp
@@ -10,14 +10,17 @@ namespace Lineside {
 
   void MultiAspectSignalHeadData::CheckData() const {
     if( this->aspectRequests.count(SignalAspect::Red) != 1 ) {
-      throw KeyNotFoundException(ToString(SignalAspect::Red));
+      std::string msg("Red aspect missing");
+      throw BadPWItemDataException(this->id, msg);
     }
     if( this->aspectRequests.count(SignalAspect::Green) != 1 ) {
-      throw KeyNotFoundException(ToString(SignalAspect::Green));
+      std::string msg("Green aspect missing");
+      throw BadPWItemDataException(this->id, msg);
     }
     if( this->aspectRequests.count(SignalAspect::Yellow2) == 1 ) {
       if( this->aspectRequests.count(SignalAspect::Yellow1) != 1 ) {
-	throw KeyNotFoundException(ToString(SignalAspect::Yellow1));
+	std::string msg("Have Yellow2 aspect but no Yellow1");
+	throw BadPWItemDataException(this->id, msg);
       }
     }
   }

--- a/src/multiaspectsignalheaddata.cpp
+++ b/src/multiaspectsignalheaddata.cpp
@@ -1,0 +1,21 @@
+#include "multiaspectsignalheaddata.hpp"
+
+#include "utility.hpp"
+
+namespace Lineside {
+  MultiAspectSignalHeadData::MultiAspectSignalHeadData() :
+    PWItemData(),
+    aspectRequests(),
+    featherRequests() {}
+
+  void MultiAspectSignalHeadData::CheckData() const {
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+
+  std::shared_ptr<PWItemModel> MultiAspectSignalHeadData::Construct( std::shared_ptr<HardwareManager> hw ) {
+    if( !hw ) {
+      throw std::logic_error("Bad hw ptr");
+    }
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+}

--- a/src/multiaspectsignalheaddata.cpp
+++ b/src/multiaspectsignalheaddata.cpp
@@ -9,7 +9,17 @@ namespace Lineside {
     featherRequests() {}
 
   void MultiAspectSignalHeadData::CheckData() const {
-    throw std::logic_error(__PRETTY_FUNCTION__);
+    if( this->aspectRequests.count(SignalAspect::Red) != 1 ) {
+      throw KeyNotFoundException(ToString(SignalAspect::Red));
+    }
+    if( this->aspectRequests.count(SignalAspect::Green) != 1 ) {
+      throw KeyNotFoundException(ToString(SignalAspect::Green));
+    }
+    if( this->aspectRequests.count(SignalAspect::Yellow2) == 1 ) {
+      if( this->aspectRequests.count(SignalAspect::Yellow1) != 1 ) {
+	throw KeyNotFoundException(ToString(SignalAspect::Yellow1));
+      }
+    }
   }
 
   std::shared_ptr<PWItemModel> MultiAspectSignalHeadData::Construct( std::shared_ptr<HardwareManager> hw ) {

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -24,6 +24,8 @@ list(APPEND srcs utilitytests.cpp)
 list(APPEND srcs registrartests.cpp)
 list(APPEND srcs pwitemcontrollertests.cpp)
 
+list(APPEND srcs multiaspectsignalheaddatatests.cpp)
+
 list(APPEND srcs servoturnoutmotortests.cpp)
 
 add_executable( LinesideTest ${srcs} )

--- a/tst/exceptiontests.cpp
+++ b/tst/exceptiontests.cpp
@@ -26,6 +26,18 @@ BOOST_AUTO_TEST_CASE(PointerLockFailureException)
   BOOST_CHECK_EQUAL( plfe.linenumber, 23 );
 }
 
+BOOST_AUTO_TEST_CASE(BadPWItemDataException)
+{
+  const Lineside::ItemId id(1);
+  const std::string info("Some information");
+
+  Lineside::BadPWItemDataException bpde(id, info);
+
+  BOOST_CHECK_EQUAL( bpde.item, id );
+  const std::string expected = "Configuration problem for 00:00:00:01 - Some information";
+  BOOST_CHECK_EQUAL( expected, bpde.what() );
+}
+
 BOOST_AUTO_TEST_CASE(KeyNotFoundException)
 {
   Lineside::KeyNotFoundException knfe("myKey");

--- a/tst/multiaspectsignalheaddatatests.cpp
+++ b/tst/multiaspectsignalheaddatatests.cpp
@@ -42,10 +42,43 @@ BOOST_AUTO_TEST_CASE(Yellow2AspectButNoYellow1)
   mashd.aspectRequests[Lineside::SignalAspect::Yellow2] = Lineside::DeviceRequestData();
 
   std::stringstream msg;
-  msg << "Key 'Yellow2' not found";
+  msg << "Key 'Yellow1' not found";
   BOOST_CHECK_EXCEPTION( mashd.CheckData(),
 			 Lineside::KeyNotFoundException,
 			 GetExceptionMessageChecker<Lineside::KeyNotFoundException>( msg.str() ) );
+}
+
+BOOST_AUTO_TEST_CASE(TwoAspectOK)
+{
+  Lineside::MultiAspectSignalHeadData mashd;
+
+  mashd.aspectRequests[Lineside::SignalAspect::Red] = Lineside::DeviceRequestData();
+  mashd.aspectRequests[Lineside::SignalAspect::Green] = Lineside::DeviceRequestData();
+
+  BOOST_CHECK_NO_THROW( mashd.CheckData() );
+}
+
+BOOST_AUTO_TEST_CASE(ThreeAspectOK)
+{
+  Lineside::MultiAspectSignalHeadData mashd;
+
+  mashd.aspectRequests[Lineside::SignalAspect::Red] = Lineside::DeviceRequestData();
+  mashd.aspectRequests[Lineside::SignalAspect::Green] = Lineside::DeviceRequestData();
+  mashd.aspectRequests[Lineside::SignalAspect::Yellow1] = Lineside::DeviceRequestData();
+
+  BOOST_CHECK_NO_THROW( mashd.CheckData() );
+}
+
+BOOST_AUTO_TEST_CASE(FourAspectOK)
+{
+  Lineside::MultiAspectSignalHeadData mashd;
+
+  mashd.aspectRequests[Lineside::SignalAspect::Red] = Lineside::DeviceRequestData();
+  mashd.aspectRequests[Lineside::SignalAspect::Green] = Lineside::DeviceRequestData();
+  mashd.aspectRequests[Lineside::SignalAspect::Yellow1] = Lineside::DeviceRequestData();
+  mashd.aspectRequests[Lineside::SignalAspect::Yellow2] = Lineside::DeviceRequestData();
+
+  BOOST_CHECK_NO_THROW( mashd.CheckData() );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/multiaspectsignalheaddatatests.cpp
+++ b/tst/multiaspectsignalheaddatatests.cpp
@@ -1,0 +1,51 @@
+#include <boost/test/unit_test.hpp>
+
+#include <sstream>
+
+#include "multiaspectsignalheaddata.hpp"
+#include "linesideexceptions.hpp"
+
+#include "exceptionmessagecheck.hpp"
+
+BOOST_AUTO_TEST_SUITE(MultiAspectSignalHeadData)
+
+BOOST_AUTO_TEST_CASE(NoRedAspect)
+{
+  Lineside::MultiAspectSignalHeadData mashd;
+
+  std::stringstream msg;
+  msg << "Key 'Red' not found";
+  BOOST_CHECK_EXCEPTION( mashd.CheckData(),
+			 Lineside::KeyNotFoundException,
+			 GetExceptionMessageChecker<Lineside::KeyNotFoundException>( msg.str() ) );
+}
+
+BOOST_AUTO_TEST_CASE(NoGreenAspect)
+{
+  Lineside::MultiAspectSignalHeadData mashd;
+
+  mashd.aspectRequests[Lineside::SignalAspect::Red] = Lineside::DeviceRequestData();
+
+  std::stringstream msg;
+  msg << "Key 'Green' not found";
+  BOOST_CHECK_EXCEPTION( mashd.CheckData(),
+			 Lineside::KeyNotFoundException,
+			 GetExceptionMessageChecker<Lineside::KeyNotFoundException>( msg.str() ) );
+}
+
+BOOST_AUTO_TEST_CASE(Yellow2AspectButNoYellow1)
+{
+  Lineside::MultiAspectSignalHeadData mashd;
+
+  mashd.aspectRequests[Lineside::SignalAspect::Red] = Lineside::DeviceRequestData();
+  mashd.aspectRequests[Lineside::SignalAspect::Green] = Lineside::DeviceRequestData();
+  mashd.aspectRequests[Lineside::SignalAspect::Yellow2] = Lineside::DeviceRequestData();
+
+  std::stringstream msg;
+  msg << "Key 'Yellow2' not found";
+  BOOST_CHECK_EXCEPTION( mashd.CheckData(),
+			 Lineside::KeyNotFoundException,
+			 GetExceptionMessageChecker<Lineside::KeyNotFoundException>( msg.str() ) );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/multiaspectsignalheaddatatests.cpp
+++ b/tst/multiaspectsignalheaddatatests.cpp
@@ -12,40 +12,40 @@ BOOST_AUTO_TEST_SUITE(MultiAspectSignalHeadData)
 BOOST_AUTO_TEST_CASE(NoRedAspect)
 {
   Lineside::MultiAspectSignalHeadData mashd;
+  mashd.id = 15;
 
-  std::stringstream msg;
-  msg << "Key 'Red' not found";
+  std::string msg = "Configuration problem for 00:00:00:0f - Red aspect missing";
   BOOST_CHECK_EXCEPTION( mashd.CheckData(),
-			 Lineside::KeyNotFoundException,
-			 GetExceptionMessageChecker<Lineside::KeyNotFoundException>( msg.str() ) );
+			 Lineside::BadPWItemDataException,
+			 GetExceptionMessageChecker<Lineside::BadPWItemDataException>( msg ) );
 }
 
 BOOST_AUTO_TEST_CASE(NoGreenAspect)
 {
   Lineside::MultiAspectSignalHeadData mashd;
+  mashd.id = 14;
 
   mashd.aspectRequests[Lineside::SignalAspect::Red] = Lineside::DeviceRequestData();
 
-  std::stringstream msg;
-  msg << "Key 'Green' not found";
+  std::string msg = "Configuration problem for 00:00:00:0e - Green aspect missing";
   BOOST_CHECK_EXCEPTION( mashd.CheckData(),
-			 Lineside::KeyNotFoundException,
-			 GetExceptionMessageChecker<Lineside::KeyNotFoundException>( msg.str() ) );
+			 Lineside::BadPWItemDataException,
+			 GetExceptionMessageChecker<Lineside::BadPWItemDataException>( msg ) );
 }
 
 BOOST_AUTO_TEST_CASE(Yellow2AspectButNoYellow1)
 {
   Lineside::MultiAspectSignalHeadData mashd;
+  mashd.id = 13;
 
   mashd.aspectRequests[Lineside::SignalAspect::Red] = Lineside::DeviceRequestData();
   mashd.aspectRequests[Lineside::SignalAspect::Green] = Lineside::DeviceRequestData();
   mashd.aspectRequests[Lineside::SignalAspect::Yellow2] = Lineside::DeviceRequestData();
 
-  std::stringstream msg;
-  msg << "Key 'Yellow1' not found";
+  std::string msg("Configuration problem for 00:00:00:0d - Have Yellow2 aspect but no Yellow1");
   BOOST_CHECK_EXCEPTION( mashd.CheckData(),
-			 Lineside::KeyNotFoundException,
-			 GetExceptionMessageChecker<Lineside::KeyNotFoundException>( msg.str() ) );
+			 Lineside::BadPWItemDataException,
+			 GetExceptionMessageChecker<Lineside::BadPWItemDataException>( msg ) );
 }
 
 BOOST_AUTO_TEST_CASE(TwoAspectOK)

--- a/tst/multiaspectsignalheaddatatests.cpp
+++ b/tst/multiaspectsignalheaddatatests.cpp
@@ -81,4 +81,55 @@ BOOST_AUTO_TEST_CASE(FourAspectOK)
   BOOST_CHECK_NO_THROW( mashd.CheckData() );
 }
 
+BOOST_AUTO_TEST_CASE(FeathersZeroDefined)
+{
+  Lineside::MultiAspectSignalHeadData mashd;
+  mashd.id = 255;
+  mashd.aspectRequests[Lineside::SignalAspect::Red] = Lineside::DeviceRequestData();
+  mashd.aspectRequests[Lineside::SignalAspect::Green] = Lineside::DeviceRequestData();
+
+  mashd.featherRequests[0] = Lineside::DeviceRequestData();
+  std::string msg = "Configuration problem for 00:00:00:ff - Feather '0' defined";
+  BOOST_CHECK_EXCEPTION( mashd.CheckData(),
+			 Lineside::BadPWItemDataException,
+			 GetExceptionMessageChecker<Lineside::BadPWItemDataException>( msg ) );
+}
+
+BOOST_AUTO_TEST_CASE(FeathersNonSequential)
+{
+  Lineside::MultiAspectSignalHeadData mashd;
+  mashd.id = 255;
+  mashd.aspectRequests[Lineside::SignalAspect::Red] = Lineside::DeviceRequestData();
+  mashd.aspectRequests[Lineside::SignalAspect::Green] = Lineside::DeviceRequestData();
+
+  mashd.featherRequests[2] = Lineside::DeviceRequestData();
+  std::string msg = "Configuration problem for 00:00:00:ff - Feathers are not sequential from one";
+  BOOST_CHECK_EXCEPTION( mashd.CheckData(),
+			 Lineside::BadPWItemDataException,
+			 GetExceptionMessageChecker<Lineside::BadPWItemDataException>( msg ) );
+}
+
+BOOST_AUTO_TEST_CASE(SingleFeatherOK)
+{
+  Lineside::MultiAspectSignalHeadData mashd;
+  mashd.id = 255;
+  mashd.aspectRequests[Lineside::SignalAspect::Red] = Lineside::DeviceRequestData();
+  mashd.aspectRequests[Lineside::SignalAspect::Green] = Lineside::DeviceRequestData();
+
+  mashd.featherRequests[1] = Lineside::DeviceRequestData();
+  BOOST_CHECK_NO_THROW( mashd.CheckData() );
+}
+
+BOOST_AUTO_TEST_CASE(TwoFeathersOK)
+{
+  Lineside::MultiAspectSignalHeadData mashd;
+  mashd.id = 255;
+  mashd.aspectRequests[Lineside::SignalAspect::Red] = Lineside::DeviceRequestData();
+  mashd.aspectRequests[Lineside::SignalAspect::Green] = Lineside::DeviceRequestData();
+
+  mashd.featherRequests[1] = Lineside::DeviceRequestData();
+  mashd.featherRequests[2] = Lineside::DeviceRequestData();
+  BOOST_CHECK_NO_THROW( mashd.CheckData() );
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add an implementation of `PWItemData` for multiple aspect signal heads.
- Implements a `CheckData()` method for basic sanity checks
- Add exception type `BadPWItemDataException` to describe issues found
- Add tests for the `CheckData()` method

The contained factory method is not yet implemented