### PR TITLE
Add multiple aspect signalhead

### DIFF
--- a/include/linesideexceptions.hpp
+++ b/include/linesideexceptions.hpp
@@ -131,4 +131,29 @@ namespace Lineside {
       this->message = tmp.str();
     }
   };
+
+  // ========================================
+
+  //! Exception for attempts to place PWItem into invalid state
+  class InvalidStateException : public LinesideException {
+  public:
+    explicit InvalidStateException(const ItemId targetItem, const std::string stateInfo) :
+      LinesideException(""),
+      target(targetItem),
+      info(stateInfo),
+      message() {
+      std::stringstream tmp;
+      tmp << "Invalid state for " << this->target << ".";
+      tmp << " State was: " << this->info;
+      this->message = tmp.str();
+    }
+    
+    const ItemId target;
+    const std::string info;
+    std::string message;
+
+    virtual const char* what() const noexcept override {
+      return this->message.c_str();
+    }
+  };
 }

--- a/include/multiaspectsignalhead.hpp
+++ b/include/multiaspectsignalhead.hpp
@@ -31,6 +31,7 @@ namespace Lineside {
     void SetState(const SignalState wantedState,
 		  const SignalFlash wantedFlash,
 		  const unsigned int wantedFeather);
+
   private:
     friend class MultiAspectSignalHeadData;
 
@@ -71,5 +72,7 @@ namespace Lineside {
     std::string buildStateString(const SignalState state,
 				 const SignalFlash flash,
 				 const unsigned int feather) const;
+    
+    void turnAllOff();
   };
 }

--- a/include/multiaspectsignalhead.hpp
+++ b/include/multiaspectsignalhead.hpp
@@ -76,5 +76,7 @@ namespace Lineside {
     void turnAllOff();
 
     void setStateFromDesired();
+
+    void setFeatherFromDesired();
   };
 }

--- a/include/multiaspectsignalhead.hpp
+++ b/include/multiaspectsignalhead.hpp
@@ -3,6 +3,7 @@
 #include <mutex>
 #include <map>
 #include <chrono>
+#include <string>
 
 #include "signalstate.hpp"
 #include "signalaspect.hpp"
@@ -66,5 +67,9 @@ namespace Lineside {
       yellow2(),
       green(),
       feathers() {}
+
+    std::string buildStateString(const SignalState state,
+				 const SignalFlash flash,
+				 const unsigned int feather) const;
   };
 }

--- a/include/multiaspectsignalhead.hpp
+++ b/include/multiaspectsignalhead.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <mutex>
+#include <map>
+#include <chrono>
+
+#include "signalstate.hpp"
+#include "signalaspect.hpp"
+#include "signalflash.hpp"
+
+#include "binaryoutputpin.hpp"
+
+#include "pwitemmodel.hpp"
+
+namespace Lineside {
+  class MultiAspectSignalHeadData;
+  
+  class MultiAspectSignalHead : public PWItemModel {
+  public:
+    const std::chrono::milliseconds FlashInterval = std::chrono::milliseconds(500);
+
+    virtual void OnActivate() override;
+
+    virtual void OnDeactivate() override;
+
+    virtual std::chrono::milliseconds OnRun() override;
+
+    virtual bool HaveStateChange() override;
+
+    void SetState(const SignalState wantedState, const unsigned int wantedFeather);
+  private:
+    friend class MultiAspectSignalHeadData;
+
+    std::mutex stateChangeMtx;
+    
+    SignalState currentState;
+    SignalState desiredState;
+    SignalFlash currentFlash;
+    SignalFlash desiredFlash;
+    unsigned int currentFeather;
+    unsigned int desiredFeather;
+
+    bool lastFlashStatus;
+    
+    std::multimap<SignalState,std::weak_ptr<BinaryOutputPin>> outputStateMap;
+    std::vector<std::weak_ptr<BinaryOutputPin>> feathers;
+
+    MultiAspectSignalHead(const ItemId signalHeadId) :
+      PWItemModel(signalHeadId),
+      stateChangeMtx(),
+      currentState(SignalState::Red),
+      desiredState(SignalState::Red),
+      currentFlash(SignalFlash::Steady),
+      desiredFlash(SignalFlash::Steady),
+      currentFeather(0),
+      desiredFeather(0),
+      lastFlashStatus(true),
+      outputStateMap(),
+      feathers() {}
+  };
+}

--- a/include/multiaspectsignalhead.hpp
+++ b/include/multiaspectsignalhead.hpp
@@ -74,5 +74,7 @@ namespace Lineside {
 				 const unsigned int feather) const;
     
     void turnAllOff();
+
+    void setStateFromDesired();
   };
 }

--- a/include/multiaspectsignalhead.hpp
+++ b/include/multiaspectsignalhead.hpp
@@ -27,7 +27,9 @@ namespace Lineside {
 
     virtual bool HaveStateChange() override;
 
-    void SetState(const SignalState wantedState, const unsigned int wantedFeather);
+    void SetState(const SignalState wantedState,
+		  const SignalFlash wantedFlash,
+		  const unsigned int wantedFeather);
   private:
     friend class MultiAspectSignalHeadData;
 

--- a/include/multiaspectsignalhead.hpp
+++ b/include/multiaspectsignalhead.hpp
@@ -42,7 +42,11 @@ namespace Lineside {
 
     bool lastFlashStatus;
     
-    std::multimap<SignalState,std::weak_ptr<BinaryOutputPin>> outputStateMap;
+    std::weak_ptr<BinaryOutputPin> red;
+    std::weak_ptr<BinaryOutputPin> yellow1;
+    std::weak_ptr<BinaryOutputPin> yellow2;
+    std::weak_ptr<BinaryOutputPin> green;
+    
     std::vector<std::weak_ptr<BinaryOutputPin>> feathers;
 
     MultiAspectSignalHead(const ItemId signalHeadId) :
@@ -55,7 +59,10 @@ namespace Lineside {
       currentFeather(0),
       desiredFeather(0),
       lastFlashStatus(true),
-      outputStateMap(),
+      red(),
+      yellow1(),
+      yellow2(),
+      green(),
       feathers() {}
   };
 }

--- a/include/multiaspectsignalhead.hpp
+++ b/include/multiaspectsignalhead.hpp
@@ -15,7 +15,8 @@
 
 namespace Lineside {
   class MultiAspectSignalHeadData;
-  
+
+  //! Implementation of a multiple aspect signal head
   class MultiAspectSignalHead : public PWItemModel {
   public:
     const std::chrono::milliseconds FlashInterval = std::chrono::milliseconds(500);
@@ -28,6 +29,7 @@ namespace Lineside {
 
     virtual bool HaveStateChange() override;
 
+    //! Set the desired state of the signal head
     void SetState(const SignalState wantedState,
 		  const SignalFlash wantedFlash,
 		  const unsigned int wantedFeather);

--- a/include/multiaspectsignalheaddata.hpp
+++ b/include/multiaspectsignalheaddata.hpp
@@ -5,8 +5,6 @@
 #include "pwitemdata.hpp"
 #include "devicerequestdata.hpp"
 #include "signalaspect.hpp"
-#include "signalstate.hpp"
-#include "binaryoutputpin.hpp"
 
 namespace Lineside {
   //! Class for configuration data for multiple aspect signal heads
@@ -19,8 +17,6 @@ namespace Lineside {
 
     //! Perform some basic sanity checks
     void CheckData() const;
-
-    std::multimap<SignalState,std::weak_ptr<BinaryOutputPin>> GenerateOutputStateMap( std::shared_ptr<HardwareManager> hw ) const;
     
     virtual std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw ) override;
   };

--- a/include/multiaspectsignalheaddata.hpp
+++ b/include/multiaspectsignalheaddata.hpp
@@ -28,6 +28,9 @@ namespace Lineside {
 					     const DeviceRequestData& drd ) const;
     
     void PopulateAspects( std::shared_ptr<HardwareManager> hw,
-			  std::shared_ptr<MultiAspectSignalHead> ) const;
+			  std::shared_ptr<MultiAspectSignalHead> target ) const;
+
+    void PopulateFeathers( std::shared_ptr<HardwareManager> hw,
+			   std::shared_ptr<MultiAspectSignalHead> target) const;
   };
 }

--- a/include/multiaspectsignalheaddata.hpp
+++ b/include/multiaspectsignalheaddata.hpp
@@ -7,6 +7,9 @@
 #include "signalaspect.hpp"
 
 namespace Lineside {
+  class BinaryOutputPin;
+  class MultiAspectSignalHead;
+  
   //! Class for configuration data for multiple aspect signal heads
   class MultiAspectSignalHeadData : public PWItemData {
   public:
@@ -19,5 +22,12 @@ namespace Lineside {
     void CheckData() const;
     
     virtual std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw ) override;
+
+  private:
+    std::weak_ptr<BinaryOutputPin> FetchBOP( std::shared_ptr<HardwareManager> hw,
+					     const DeviceRequestData& drd ) const;
+    
+    void PopulateAspects( std::shared_ptr<HardwareManager> hw,
+			  std::shared_ptr<MultiAspectSignalHead> ) const;
   };
 }

--- a/include/multiaspectsignalheaddata.hpp
+++ b/include/multiaspectsignalheaddata.hpp
@@ -5,6 +5,8 @@
 #include "pwitemdata.hpp"
 #include "devicerequestdata.hpp"
 #include "signalaspect.hpp"
+#include "signalstate.hpp"
+#include "binaryoutputpin.hpp"
 
 namespace Lineside {
   //! Class for configuration data for multiple aspect signal heads
@@ -17,6 +19,8 @@ namespace Lineside {
 
     //! Perform some basic sanity checks
     void CheckData() const;
+
+    std::multimap<SignalState,std::weak_ptr<BinaryOutputPin>> GenerateOutputStateMap( std::shared_ptr<HardwareManager> hw ) const;
     
     virtual std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw ) override;
   };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ list(APPEND srcs servoturnoutmotordata.cpp)
 list(APPEND srcs servoturnoutmotor.cpp)
 
 list(APPEND srcs multiaspectsignalheaddata.cpp)
+list(APPEND srcs multiaspectsignalhead.cpp)
 
 add_library( lineside ${srcs} )
 target_include_directories(lineside

--- a/src/multiaspectsignalhead.cpp
+++ b/src/multiaspectsignalhead.cpp
@@ -24,9 +24,43 @@ namespace Lineside {
 				       const SignalFlash wantedFlash,
 				       const unsigned int wantedFeather ) {
     std::lock_guard<std::mutex> lockState(this->stateChangeMtx);
+
+    // Checks on the aspects
+    if( wantedState == SignalState::Yellow ) {
+      if( this->yellow1.expired() ) {
+	auto stateString = this->buildStateString(wantedState, wantedFlash, wantedFeather);
+	throw InvalidStateException(this->getId(), stateString);
+      }
+    }
+
+    if( wantedState == SignalState::DoubleYellow ) {
+      if( this->yellow2.expired() ) {
+	auto stateString = this->buildStateString(wantedState, wantedFlash, wantedFeather);
+	throw InvalidStateException(this->getId(), stateString);
+      }
+    }
+
+    // Check on the feather
+    if( wantedFeather > this->feathers.size() ) {
+      auto stateString = this->buildStateString(wantedState, wantedFlash, wantedFeather);
+      throw InvalidStateException(this->getId(), stateString);
+    }
+    
     this->desiredState = wantedState;
     this->desiredFlash = wantedFlash;
     this->desiredFeather = wantedFeather;
     this->WakeController();
   }
+
+  std::string MultiAspectSignalHead::buildStateString(const SignalState state,
+						      const SignalFlash flash,
+						      const unsigned int feather) const {
+    std::stringstream result;
+    result << "{"
+	   << state << ","
+	   << flash << ","
+	   << feather << "}";
+    return result.str();
+  }
+
 }

--- a/src/multiaspectsignalhead.cpp
+++ b/src/multiaspectsignalhead.cpp
@@ -15,7 +15,15 @@ namespace Lineside {
 
   std::chrono::milliseconds MultiAspectSignalHead::OnRun() {
     std::lock_guard<std::mutex> lockState(this->stateChangeMtx);
-    throw std::logic_error(__PRETTY_FUNCTION__);
+
+    this->turnAllOff();
+
+    this->setStateFromDesired();
+
+    this->currentState = this->desiredState;
+    this->currentFlash = this->desiredFlash;
+    this->currentFeather = this->desiredFeather;
+    return MultiAspectSignalHead::FlashInterval;
   }
 
   bool MultiAspectSignalHead::HaveStateChange() {
@@ -90,6 +98,29 @@ namespace Lineside {
     for( auto it=this->feathers.begin(); it!=this->feathers.end(); ++it ) {
       LOCK_OR_THROW( f, (*it) );
       f->Set(false);
+    }
+  }
+
+  void MultiAspectSignalHead::setStateFromDesired() {
+    // Assumes that turnAllOff() called previously, and that
+    // SetState has prevented desiredState being invalid
+    if( this->desiredState == SignalState::Red ) {
+      LOCK_OR_THROW( r, this->red );
+      r->Set(true);
+    }
+    if( this->desiredState == SignalState::Yellow ) {
+      LOCK_OR_THROW( y1, this->yellow1 );
+      y1->Set(true);
+    }
+    if( this->desiredState == SignalState::DoubleYellow ) {
+      LOCK_OR_THROW( y1, this->yellow1 );
+      y1->Set(true);
+      LOCK_OR_THROW( y2, this->yellow2 );
+      y2->Set(true);
+    }
+    if( this->desiredState == SignalState::Green ) {
+      LOCK_OR_THROW( g, this->green );
+      g->Set(true);
     }
   }
 }

--- a/src/multiaspectsignalhead.cpp
+++ b/src/multiaspectsignalhead.cpp
@@ -4,24 +4,9 @@
 
 namespace Lineside {
   void MultiAspectSignalHead::OnActivate() {
-    LOCK_OR_THROW( g, this->green );
-    g->Set(false);
+    this->turnAllOff();
     LOCK_OR_THROW( r, this->red );
     r->Set(true);
-    
-    if( !this->yellow1.expired() ) {
-      LOCK_OR_THROW( y1, this->yellow1 );
-      y1->Set(false);
-    }
-    if( !this->yellow2.expired() ) {
-      LOCK_OR_THROW( y2, this->yellow2 );
-      y2->Set(false);
-    }
-
-    for( auto it=this->feathers.begin(); it!=this->feathers.end(); ++it ) {
-      LOCK_OR_THROW( f, (*it) );
-      f->Set(false);
-    }
   }
 
   void MultiAspectSignalHead::OnDeactivate() {
@@ -83,5 +68,28 @@ namespace Lineside {
 	   << feather << "}";
     return result.str();
   }
-
+  
+  void MultiAspectSignalHead::turnAllOff() {
+    // Always have Red and Green aspects
+    LOCK_OR_THROW( g, this->green );
+    g->Set(false);
+    LOCK_OR_THROW( r, this->red );
+    r->Set(false);
+    
+    // Check for Yellows
+    if( !this->yellow1.expired() ) {
+      LOCK_OR_THROW( y1, this->yellow1 );
+      y1->Set(false);
+    }
+    if( !this->yellow2.expired() ) {
+      LOCK_OR_THROW( y2, this->yellow2 );
+      y2->Set(false);
+    }
+    
+    // Check for feathers
+    for( auto it=this->feathers.begin(); it!=this->feathers.end(); ++it ) {
+      LOCK_OR_THROW( f, (*it) );
+      f->Set(false);
+    }
+  }
 }

--- a/src/multiaspectsignalhead.cpp
+++ b/src/multiaspectsignalhead.cpp
@@ -10,7 +10,7 @@ namespace Lineside {
   }
 
   void MultiAspectSignalHead::OnDeactivate() {
-    throw std::logic_error(__PRETTY_FUNCTION__);
+    this->turnAllOff();
   }
 
   std::chrono::milliseconds MultiAspectSignalHead::OnRun() {

--- a/src/multiaspectsignalhead.cpp
+++ b/src/multiaspectsignalhead.cpp
@@ -1,0 +1,9 @@
+#include "utility.hpp"
+
+#include "multiaspectsignalhead.hpp"
+
+namespace Lineside {
+  void MultiAspectSignalHead::OnActivate() {
+
+  }
+}

--- a/src/multiaspectsignalhead.cpp
+++ b/src/multiaspectsignalhead.cpp
@@ -4,6 +4,29 @@
 
 namespace Lineside {
   void MultiAspectSignalHead::OnActivate() {
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
 
+  void MultiAspectSignalHead::OnDeactivate() {
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+
+  std::chrono::milliseconds MultiAspectSignalHead::OnRun() {
+    std::lock_guard<std::mutex> lockState(this->stateChangeMtx);
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+
+  bool MultiAspectSignalHead::HaveStateChange() {
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+
+  void MultiAspectSignalHead::SetState(const SignalState wantedState,
+				       const SignalFlash wantedFlash,
+				       const unsigned int wantedFeather ) {
+    std::lock_guard<std::mutex> lockState(this->stateChangeMtx);
+    this->desiredState = wantedState;
+    this->desiredFlash = wantedFlash;
+    this->desiredFeather = wantedFeather;
+    this->WakeController();
   }
 }

--- a/src/multiaspectsignalhead.cpp
+++ b/src/multiaspectsignalhead.cpp
@@ -4,7 +4,24 @@
 
 namespace Lineside {
   void MultiAspectSignalHead::OnActivate() {
-    throw std::logic_error(__PRETTY_FUNCTION__);
+    LOCK_OR_THROW( g, this->green );
+    g->Set(false);
+    LOCK_OR_THROW( r, this->red );
+    r->Set(true);
+    
+    if( !this->yellow1.expired() ) {
+      LOCK_OR_THROW( y1, this->yellow1 );
+      y1->Set(false);
+    }
+    if( !this->yellow2.expired() ) {
+      LOCK_OR_THROW( y2, this->yellow2 );
+      y2->Set(false);
+    }
+
+    for( auto it=this->feathers.begin(); it!=this->feathers.end(); ++it ) {
+      LOCK_OR_THROW( f, (*it) );
+      f->Set(false);
+    }
   }
 
   void MultiAspectSignalHead::OnDeactivate() {
@@ -17,7 +34,11 @@ namespace Lineside {
   }
 
   bool MultiAspectSignalHead::HaveStateChange() {
-    throw std::logic_error(__PRETTY_FUNCTION__);
+    bool changeState = this->desiredState != this->currentState;
+    bool changeFlash = this->desiredFlash != this->currentFlash;
+    bool changeFeather = this->desiredFeather != this->currentFeather;
+
+    return changeState || changeFlash || changeFeather;
   }
 
   void MultiAspectSignalHead::SetState(const SignalState wantedState,

--- a/src/multiaspectsignalhead.cpp
+++ b/src/multiaspectsignalhead.cpp
@@ -104,23 +104,28 @@ namespace Lineside {
   void MultiAspectSignalHead::setStateFromDesired() {
     // Assumes that turnAllOff() called previously, and that
     // SetState has prevented desiredState being invalid
+    const bool isSteady = this->desiredFlash == SignalFlash::Steady;
+    const bool nextOnOff = isSteady || this->lastFlashStatus;
+    
     if( this->desiredState == SignalState::Red ) {
       LOCK_OR_THROW( r, this->red );
-      r->Set(true);
+      r->Set(nextOnOff);
     }
     if( this->desiredState == SignalState::Yellow ) {
       LOCK_OR_THROW( y1, this->yellow1 );
-      y1->Set(true);
+      y1->Set(nextOnOff);
     }
     if( this->desiredState == SignalState::DoubleYellow ) {
       LOCK_OR_THROW( y1, this->yellow1 );
-      y1->Set(true);
+      y1->Set(nextOnOff);
       LOCK_OR_THROW( y2, this->yellow2 );
-      y2->Set(true);
+      y2->Set(nextOnOff);
     }
     if( this->desiredState == SignalState::Green ) {
       LOCK_OR_THROW( g, this->green );
-      g->Set(true);
+      g->Set(nextOnOff);
     }
+
+    this->lastFlashStatus = !this->lastFlashStatus;
   }
 }

--- a/src/multiaspectsignalhead.cpp
+++ b/src/multiaspectsignalhead.cpp
@@ -20,6 +20,8 @@ namespace Lineside {
 
     this->setStateFromDesired();
 
+    this->setFeatherFromDesired();
+
     this->currentState = this->desiredState;
     this->currentFlash = this->desiredFlash;
     this->currentFeather = this->desiredFeather;
@@ -127,5 +129,14 @@ namespace Lineside {
     }
 
     this->lastFlashStatus = !this->lastFlashStatus;
+  }
+
+  void MultiAspectSignalHead::setFeatherFromDesired() {
+    // Assumes that turnAllOff() called previously, and that
+    // SetState has prevented desiredFeather being invalid
+    if( this->desiredFeather > 0 ) {
+      LOCK_OR_THROW( f, this->feathers.at(this->desiredFeather-1) );
+      f->Set(true);
+    }
   }
 }

--- a/src/multiaspectsignalheaddata.cpp
+++ b/src/multiaspectsignalheaddata.cpp
@@ -60,6 +60,7 @@ namespace Lineside {
     auto result = std::make_shared<enabler>(this->id);
 
     this->PopulateAspects( hw, result );
+    this->PopulateFeathers( hw, result );
     
     return result;
   }
@@ -88,6 +89,18 @@ namespace Lineside {
       if( this->aspectRequests.count(SignalAspect::Yellow2) == 1 ) {
 	target->yellow2 = this->FetchBOP( hw, this->aspectRequests.at(SignalAspect::Yellow2) );
       }
+    }
+  }
+
+  void MultiAspectSignalHeadData::PopulateFeathers( std::shared_ptr<HardwareManager> hw,
+						    std::shared_ptr<MultiAspectSignalHead> target ) const {
+    // Calling from private method, so assume CheckData() has been called
+
+    // The map is nicely sorted by the keys (which are unsigned ints)
+    for( auto it = this->featherRequests.begin();
+	 it != this->featherRequests.end();
+	 ++it ) {
+      target->feathers.push_back( this->FetchBOP( hw, it->second ) );
     }
   }
 }

--- a/src/multiaspectsignalheaddata.cpp
+++ b/src/multiaspectsignalheaddata.cpp
@@ -43,6 +43,18 @@ namespace Lineside {
     }
   }
 
+  std::multimap<SignalState,std::weak_ptr<BinaryOutputPin>> MultiAspectSignalHeadData::GenerateOutputStateMap( std::shared_ptr<HardwareManager> hw ) const {
+    if( !hw ) {
+      throw std::logic_error("Bad hw ptr");
+    }
+
+    this->CheckData();
+
+    std::multimap<SignalState,std::weak_ptr<BinaryOutputPin>> result;
+
+    return result;
+  }
+  
   std::shared_ptr<PWItemModel> MultiAspectSignalHeadData::Construct( std::shared_ptr<HardwareManager> hw ) {
     if( !hw ) {
       throw std::logic_error("Bad hw ptr");

--- a/src/multiaspectsignalheaddata.cpp
+++ b/src/multiaspectsignalheaddata.cpp
@@ -81,5 +81,13 @@ namespace Lineside {
     // Must have red and green aspects
     target->red = this->FetchBOP( hw, this->aspectRequests.at(SignalAspect::Red) );
     target->green = this->FetchBOP( hw, this->aspectRequests.at(SignalAspect::Green) );
+
+    if( this->aspectRequests.count(SignalAspect::Yellow1) == 1 ) {
+      target->yellow1 = this->FetchBOP( hw, this->aspectRequests.at(SignalAspect::Yellow1) );
+      
+      if( this->aspectRequests.count(SignalAspect::Yellow2) == 1 ) {
+	target->yellow2 = this->FetchBOP( hw, this->aspectRequests.at(SignalAspect::Yellow2) );
+      }
+    }
   }
 }

--- a/src/multiaspectsignalheaddata.cpp
+++ b/src/multiaspectsignalheaddata.cpp
@@ -43,18 +43,6 @@ namespace Lineside {
     }
   }
 
-  std::multimap<SignalState,std::weak_ptr<BinaryOutputPin>> MultiAspectSignalHeadData::GenerateOutputStateMap( std::shared_ptr<HardwareManager> hw ) const {
-    if( !hw ) {
-      throw std::logic_error("Bad hw ptr");
-    }
-
-    this->CheckData();
-
-    std::multimap<SignalState,std::weak_ptr<BinaryOutputPin>> result;
-
-    return result;
-  }
-  
   std::shared_ptr<PWItemModel> MultiAspectSignalHeadData::Construct( std::shared_ptr<HardwareManager> hw ) {
     if( !hw ) {
       throw std::logic_error("Bad hw ptr");

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -25,6 +25,7 @@ list(APPEND srcs registrartests.cpp)
 list(APPEND srcs pwitemcontrollertests.cpp)
 
 list(APPEND srcs multiaspectsignalheaddatatests.cpp)
+list(APPEND srcs multiaspectsignalheadtests.cpp)
 
 list(APPEND srcs servoturnoutmotortests.cpp)
 

--- a/tst/exceptiontests.cpp
+++ b/tst/exceptiontests.cpp
@@ -56,4 +56,17 @@ BOOST_AUTO_TEST_CASE(DuplicateKeyException)
   BOOST_CHECK_EQUAL(expected, dke.what());
 }
 
+BOOST_AUTO_TEST_CASE(InvalidStateException)
+{
+  const Lineside::ItemId id(256);
+  const std::string stateInfo("Something or other");
+
+  Lineside::InvalidStateException ise( id, stateInfo );
+  BOOST_CHECK_EQUAL( ise.target, id );
+  BOOST_CHECK_EQUAL( ise.info, stateInfo );
+
+  const std::string expected = "Invalid state for 00:00:01:00. State was: Something or other";
+  BOOST_CHECK_EQUAL( ise.what(), expected );
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/multiaspectsignalheaddatatests.cpp
+++ b/tst/multiaspectsignalheaddatatests.cpp
@@ -4,15 +4,10 @@
 
 #include "multiaspectsignalheaddata.hpp"
 #include "linesideexceptions.hpp"
-#include "utility.hpp"
-
-#include "mockhardwaremanagerfixture.hpp"
 
 #include "exceptionmessagecheck.hpp"
 
-BOOST_FIXTURE_TEST_SUITE(MultiAspectSignalHeadData, MockHardwareManagerFixture)
-
-BOOST_AUTO_TEST_SUITE(CheckData)
+BOOST_AUTO_TEST_SUITE(MultiAspectSignalHeadData)
 
 BOOST_AUTO_TEST_CASE(NoRedAspect)
 {
@@ -137,59 +132,4 @@ BOOST_AUTO_TEST_CASE(TwoFeathersOK)
   BOOST_CHECK_NO_THROW( mashd.CheckData() );
 }
 
-BOOST_AUTO_TEST_SUITE_END()
-
-// ================================================
-
-BOOST_AUTO_TEST_SUITE(GenerateOutputStateMap)
-
-BOOST_AUTO_TEST_CASE(TwoAspect)
-{
-  const std::string controller = "MockBOPController";
-  const std::string redData = "07";
-  const std::string greenData = "08";
-  Lineside::MultiAspectSignalHeadData mashd;
-  mashd.id = 255;
-
-  Lineside::DeviceRequestData redRequest, greenRequest;
-  redRequest.controller = this->hwManager->BOPProviderId;
-  greenRequest.controller = this->hwManager->BOPProviderId;
-  redRequest.controllerData = redData;
-  greenRequest.controllerData = greenData;
-  
-  
-  mashd.aspectRequests[Lineside::SignalAspect::Red] = redRequest;
-  mashd.aspectRequests[Lineside::SignalAspect::Green] = greenRequest;
-
-  auto res = mashd.GenerateOutputStateMap( this->hwManager );
-  BOOST_CHECK_EQUAL( res.size(), 2 );
-
-  // Check that the right states are present, and controlling the correct
-  // number of lamps. Make these comparisons required so that we can
-  // assume subsequent operations on the multimap will succeed
-  BOOST_REQUIRE_EQUAL( res.count(Lineside::SignalState::Red), 1 );
-  BOOST_REQUIRE_EQUAL( res.count(Lineside::SignalState::Green), 1 );
-
-  // Since there's only one of each, we can use multimap::find
-  auto redIt = res.find(Lineside::SignalState::Red);
-  LOCK_OR_THROW( redPin, redIt->second );
-  BOOST_CHECK_EQUAL( redPin, this->hwManager->bopProvider->pins.at(redData) );
-
-  auto greenIt = res.find(Lineside::SignalState::Green);
-  LOCK_OR_THROW( greenPin, greenIt->second );
-  BOOST_CHECK_EQUAL( greenPin, this->hwManager->bopProvider->pins.at(greenData) );
-}
-
-BOOST_AUTO_TEST_CASE(ThreeAspect)
-{
-  BOOST_FAIL("Not yet implemented");
-}
-
-BOOST_AUTO_TEST_CASE(FourAspect)
-{
-  BOOST_FAIL("Not yet implemented");
-}
-
-BOOST_AUTO_TEST_SUITE_END()
-  
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/multiaspectsignalheaddatatests.cpp
+++ b/tst/multiaspectsignalheaddatatests.cpp
@@ -4,10 +4,15 @@
 
 #include "multiaspectsignalheaddata.hpp"
 #include "linesideexceptions.hpp"
+#include "utility.hpp"
+
+#include "mockhardwaremanagerfixture.hpp"
 
 #include "exceptionmessagecheck.hpp"
 
-BOOST_AUTO_TEST_SUITE(MultiAspectSignalHeadData)
+BOOST_FIXTURE_TEST_SUITE(MultiAspectSignalHeadData, MockHardwareManagerFixture)
+
+BOOST_AUTO_TEST_SUITE(CheckData)
 
 BOOST_AUTO_TEST_CASE(NoRedAspect)
 {
@@ -132,4 +137,59 @@ BOOST_AUTO_TEST_CASE(TwoFeathersOK)
   BOOST_CHECK_NO_THROW( mashd.CheckData() );
 }
 
+BOOST_AUTO_TEST_SUITE_END()
+
+// ================================================
+
+BOOST_AUTO_TEST_SUITE(GenerateOutputStateMap)
+
+BOOST_AUTO_TEST_CASE(TwoAspect)
+{
+  const std::string controller = "MockBOPController";
+  const std::string redData = "07";
+  const std::string greenData = "08";
+  Lineside::MultiAspectSignalHeadData mashd;
+  mashd.id = 255;
+
+  Lineside::DeviceRequestData redRequest, greenRequest;
+  redRequest.controller = this->hwManager->BOPProviderId;
+  greenRequest.controller = this->hwManager->BOPProviderId;
+  redRequest.controllerData = redData;
+  greenRequest.controllerData = greenData;
+  
+  
+  mashd.aspectRequests[Lineside::SignalAspect::Red] = redRequest;
+  mashd.aspectRequests[Lineside::SignalAspect::Green] = greenRequest;
+
+  auto res = mashd.GenerateOutputStateMap( this->hwManager );
+  BOOST_CHECK_EQUAL( res.size(), 2 );
+
+  // Check that the right states are present, and controlling the correct
+  // number of lamps. Make these comparisons required so that we can
+  // assume subsequent operations on the multimap will succeed
+  BOOST_REQUIRE_EQUAL( res.count(Lineside::SignalState::Red), 1 );
+  BOOST_REQUIRE_EQUAL( res.count(Lineside::SignalState::Green), 1 );
+
+  // Since there's only one of each, we can use multimap::find
+  auto redIt = res.find(Lineside::SignalState::Red);
+  LOCK_OR_THROW( redPin, redIt->second );
+  BOOST_CHECK_EQUAL( redPin, this->hwManager->bopProvider->pins.at(redData) );
+
+  auto greenIt = res.find(Lineside::SignalState::Green);
+  LOCK_OR_THROW( greenPin, greenIt->second );
+  BOOST_CHECK_EQUAL( greenPin, this->hwManager->bopProvider->pins.at(greenData) );
+}
+
+BOOST_AUTO_TEST_CASE(ThreeAspect)
+{
+  BOOST_FAIL("Not yet implemented");
+}
+
+BOOST_AUTO_TEST_CASE(FourAspect)
+{
+  BOOST_FAIL("Not yet implemented");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+  
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -202,11 +202,131 @@ BOOST_AUTO_TEST_CASE(ConstructTwoAspectWithTwoFeathers)
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(feather2Data), 1);
 }
 
+BOOST_AUTO_TEST_CASE(TwoAspectSetState)
+{
+  const Lineside::ItemId id(11);
+  
+  auto mashd = MakeTwoAspect( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  auto allowedStates = std::set<Lineside::SignalState> { Lineside::SignalState::Red,
+							 Lineside::SignalState::Green };
+  auto allowedFlash = std::set<Lineside::SignalFlash> { Lineside::SignalFlash::Steady,
+							Lineside::SignalFlash::Flashing };
+  const unsigned int feather = 0;
+  for( auto itState=allowedStates.begin();
+       itState!=allowedStates.end();
+       ++itState ) {
+    for( auto itFlash=allowedFlash.begin();
+	 itFlash!=allowedFlash.end();
+	 ++itFlash ) {
+      BOOST_CHECK_NO_THROW( resMASH->SetState( *itState, *itFlash, feather ) );
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(ThreeAspectSetState)
+{
+  const Lineside::ItemId id(11);
+  
+  auto mashd = MakeThreeAspect( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  auto allowedStates = std::set<Lineside::SignalState> { Lineside::SignalState::Red,
+							 Lineside::SignalState::Yellow,
+							 Lineside::SignalState::Green };
+  auto allowedFlash = std::set<Lineside::SignalFlash> { Lineside::SignalFlash::Steady,
+							Lineside::SignalFlash::Flashing };
+  const unsigned int feather = 0;
+  for( auto itState=allowedStates.begin();
+       itState!=allowedStates.end();
+       ++itState ) {
+    for( auto itFlash=allowedFlash.begin();
+	 itFlash!=allowedFlash.end();
+	 ++itFlash ) {
+      BOOST_CHECK_NO_THROW( resMASH->SetState( *itState, *itFlash, feather ) );
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(FourAspectSetState)
+{
+  const Lineside::ItemId id(11);
+  
+  auto mashd = MakeFourAspect( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  auto allowedStates = std::set<Lineside::SignalState> { Lineside::SignalState::Red,
+							 Lineside::SignalState::Yellow,
+							 Lineside::SignalState::DoubleYellow,
+							 Lineside::SignalState::Green };
+  auto allowedFlash = std::set<Lineside::SignalFlash> { Lineside::SignalFlash::Steady,
+							Lineside::SignalFlash::Flashing };
+  const unsigned int feather = 0;
+  for( auto itState=allowedStates.begin();
+       itState!=allowedStates.end();
+       ++itState ) {
+    for( auto itFlash=allowedFlash.begin();
+	 itFlash!=allowedFlash.end();
+	 ++itFlash ) {
+      BOOST_CHECK_NO_THROW( resMASH->SetState( *itState, *itFlash, feather ) );
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(TwoAspectSetStateWithTwoFeathers)
+{
+  const Lineside::ItemId id(11);
+  
+  auto mashd = MakeTwoAspectTwoFeather( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  auto allowedStates = std::set<Lineside::SignalState> { Lineside::SignalState::Red,
+							 Lineside::SignalState::Green };
+  auto allowedFlash = std::set<Lineside::SignalFlash> { Lineside::SignalFlash::Steady,
+							Lineside::SignalFlash::Flashing };
+  auto allowedFeather = std::set<unsigned int> { 0, 1, 2 };
+  
+  for( auto itState=allowedStates.begin();
+       itState!=allowedStates.end();
+       ++itState ) {
+    for( auto itFlash=allowedFlash.begin();
+	 itFlash!=allowedFlash.end();
+	 ++itFlash ) {
+      for( auto itFeather=allowedFeather.begin();
+	   itFeather!=allowedFeather.end();
+	   ++itFeather ) {
+	BOOST_CHECK_NO_THROW( resMASH->SetState( *itState, *itFlash, *itFeather ) );
+      }
+    }
+  }
+}
+
 BOOST_AUTO_TEST_CASE(TwoAspectSetStateThrowsOnBadAspect)
 {
   BOOST_FAIL("Not yet implemented");
 }
-
+    
 BOOST_AUTO_TEST_CASE(ThreeAspectSetStateThrowsOnBadAspect)
 {
   BOOST_FAIL("Not yet implemented");

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -462,9 +462,79 @@ BOOST_AUTO_TEST_CASE(TwoAspectOneFeatherSetStateThrowsOnBadFeather)
 }
 
 
-BOOST_AUTO_TEST_CASE(ShowsRedOnActivate)
+BOOST_AUTO_TEST_CASE(ShowsRedOnActivateTwoAspect)
 {
-  BOOST_FAIL("Not yet implemented");
+  const Lineside::ItemId id(11);
+  
+  auto mashd = MakeTwoAspect( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+
+  // Activate the signal head
+  res->OnActivate();
+
+  // Check we're now showing Red
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+}
+
+BOOST_AUTO_TEST_CASE(ShowsRedOnActivateFourAspect)
+{
+  const Lineside::ItemId id(11);
+  
+  auto mashd = MakeFourAspect( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+
+  // Activate the signal head
+  res->OnActivate();
+
+  // Check we're now showing Red
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+}
+
+BOOST_AUTO_TEST_CASE(ShowsRedOnActivateTwoAspectWithFeather)
+{
+  const Lineside::ItemId id(11);
+  
+  auto mashd = MakeTwoAspectOneFeather( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(feather1Data)->Get(), false );
+
+  // Activate the signal head
+  res->OnActivate();
+
+  // Check we're now showing Red
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(feather1Data)->Get(), false );
 }
 
 BOOST_AUTO_TEST_CASE(OnRunDoesSomething)

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -34,6 +34,33 @@ Lineside::MultiAspectSignalHeadData MakeTwoAspect( const Lineside::ItemId id,
   return mashd;
 }
 
+Lineside::MultiAspectSignalHeadData MakeThreeAspect( const Lineside::ItemId id,
+						     const std::string controller ) {
+  Lineside::MultiAspectSignalHeadData mashd;
+
+  mashd.id = id;
+  AddAspect( mashd, controller, Lineside::SignalAspect::Red, redData );
+  AddAspect( mashd, controller, Lineside::SignalAspect::Yellow1, yellow1Data );
+  AddAspect( mashd, controller, Lineside::SignalAspect::Green, greenData );
+
+  return mashd;
+}
+
+Lineside::MultiAspectSignalHeadData MakeFourAspect( const Lineside::ItemId id,
+						    const std::string controller ) {
+  Lineside::MultiAspectSignalHeadData mashd;
+
+  mashd.id = id;
+  AddAspect( mashd, controller, Lineside::SignalAspect::Red, redData );
+  AddAspect( mashd, controller, Lineside::SignalAspect::Yellow1, yellow1Data );
+  AddAspect( mashd, controller, Lineside::SignalAspect::Yellow2, yellow2Data );
+  AddAspect( mashd, controller, Lineside::SignalAspect::Green, greenData );
+
+  return mashd;
+}
+
+
+
 // =====================================
 
 BOOST_FIXTURE_TEST_SUITE(MultiAspectSignalHead, MockHardwareManagerFixture)
@@ -60,12 +87,45 @@ BOOST_AUTO_TEST_CASE(ConstructTwoAspect)
 
 BOOST_AUTO_TEST_CASE(ConstructThreeAspect)
 {
-  BOOST_FAIL("Not yet implemented");
+  const Lineside::ItemId id(12);
+
+  auto mashd = MakeThreeAspect( id, this->hwManager->BOPProviderId );
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  // Ensure we have got the right number of output pins assigned
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.size(), 3 );
+
+  // Check that the right pins were assigned
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(redData), 1 );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(yellow1Data), 1 );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(greenData), 1 );
 }
 
 BOOST_AUTO_TEST_CASE(ConstructFourAspect)
 {
-  BOOST_FAIL("Not yet implemented");
+  const Lineside::ItemId id(12);
+  
+  auto mashd = MakeFourAspect( id, this->hwManager->BOPProviderId );
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  // Ensure we have got the right number of output pins assigned
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.size(), 4 );
+
+  // Check that the right pins were assigned
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(redData), 1 );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(yellow1Data), 1 );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(yellow2Data), 1 );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(greenData), 1 );
 }
 
 BOOST_AUTO_TEST_CASE(ConstructTwoAspectWithOneFeather)

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -461,4 +461,15 @@ BOOST_AUTO_TEST_CASE(TwoAspectOneFeatherSetStateThrowsOnBadFeather)
   }
 }
 
+
+BOOST_AUTO_TEST_CASE(ShowsRedOnActivate)
+{
+  BOOST_FAIL("Not yet implemented");
+}
+
+BOOST_AUTO_TEST_CASE(OnRunDoesSomething)
+{
+  BOOST_FAIL("Have several of these to write");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -556,7 +556,8 @@ BOOST_AUTO_TEST_CASE(OnRunTwoAspectSteady)
   // Set to Green
   resMASH->SetState( Lineside::SignalState::Green, Lineside::SignalFlash::Steady, 0 );
   BOOST_CHECK( resMASH->HaveStateChange() );
-  
+  auto sleepTime = resMASH->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), true );
 
@@ -564,13 +565,16 @@ BOOST_AUTO_TEST_CASE(OnRunTwoAspectSteady)
   BOOST_CHECK( !resMASH->HaveStateChange() );
   resMASH->SetState( Lineside::SignalState::Green, Lineside::SignalFlash::Steady, 0 );
   BOOST_CHECK( !resMASH->HaveStateChange() );
+  sleepTime = resMASH->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), true );
   
   // Set to Red
   resMASH->SetState( Lineside::SignalState::Red, Lineside::SignalFlash::Steady, 0 );
   BOOST_CHECK( resMASH->HaveStateChange() );
-  
+  sleepTime = resMASH->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
 }
@@ -595,6 +599,8 @@ BOOST_AUTO_TEST_CASE(OnRunThreeAspectSteady)
   // Set to Green
   resMASH->SetState( Lineside::SignalState::Green, Lineside::SignalFlash::Steady, 0 );
   BOOST_CHECK( resMASH->HaveStateChange() );
+  auto sleepTime = resMASH->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), true );
@@ -602,6 +608,8 @@ BOOST_AUTO_TEST_CASE(OnRunThreeAspectSteady)
   // Set to Yellow
   resMASH->SetState( Lineside::SignalState::Yellow, Lineside::SignalFlash::Steady, 0 );
   BOOST_CHECK( resMASH->HaveStateChange() );
+  sleepTime = resMASH->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), true );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
@@ -609,6 +617,8 @@ BOOST_AUTO_TEST_CASE(OnRunThreeAspectSteady)
   // Set to Red
   resMASH->SetState( Lineside::SignalState::Red, Lineside::SignalFlash::Steady, 0 );
   BOOST_CHECK( resMASH->HaveStateChange() );
+  sleepTime = resMASH->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
@@ -635,6 +645,8 @@ BOOST_AUTO_TEST_CASE(OnRunFourAspectSteady)
   // Set to Green
   resMASH->SetState( Lineside::SignalState::Green, Lineside::SignalFlash::Steady, 0 );
   BOOST_CHECK( resMASH->HaveStateChange() );
+  auto sleepTime = resMASH->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), false );
@@ -643,6 +655,8 @@ BOOST_AUTO_TEST_CASE(OnRunFourAspectSteady)
   // Set to Double Yellow
   resMASH->SetState( Lineside::SignalState::DoubleYellow, Lineside::SignalFlash::Steady, 0 );
   BOOST_CHECK( resMASH->HaveStateChange() );
+  sleepTime = resMASH->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), true );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), true );
@@ -651,6 +665,8 @@ BOOST_AUTO_TEST_CASE(OnRunFourAspectSteady)
   // Set to Yellow
   resMASH->SetState( Lineside::SignalState::Yellow, Lineside::SignalFlash::Steady, 0 );
   BOOST_CHECK( resMASH->HaveStateChange() );
+  sleepTime = resMASH->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), true );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), false );
@@ -659,6 +675,8 @@ BOOST_AUTO_TEST_CASE(OnRunFourAspectSteady)
   // Set to Red
   resMASH->SetState( Lineside::SignalState::Red, Lineside::SignalFlash::Steady, 0 );
   BOOST_CHECK( resMASH->HaveStateChange() );
+  sleepTime = resMASH->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), false );

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -29,11 +29,16 @@ BOOST_AUTO_TEST_CASE(ConstructTwoAspect)
 
   auto res = mashd.Construct( this->hwManager );
   BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
   BOOST_REQUIRE( resMASH );
 
   // Ensure we have got the right number of output pins assigned
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.size(), 2 );
+
+  // Check that the right pins were assigned
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(redData), 1 );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(greenData), 1 );
 }
 
 BOOST_AUTO_TEST_CASE(ConstructThreeAspect)

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -29,6 +29,31 @@ BOOST_AUTO_TEST_CASE(ConstructTwoAspect)
 
   auto res = mashd.Construct( this->hwManager );
   BOOST_REQUIRE( res );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  // Ensure we have got the right number of output pins assigned
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.size(), 2 );
+}
+
+BOOST_AUTO_TEST_CASE(ConstructThreeAspect)
+{
+  BOOST_FAIL("Not yet implemented");
+}
+
+BOOST_AUTO_TEST_CASE(ConstructFourAspect)
+{
+  BOOST_FAIL("Not yet implemented");
+}
+
+BOOST_AUTO_TEST_CASE(ConstructTwoAspectWithOneFeather)
+{
+  BOOST_FAIL("Not yet implemented");
+}
+
+BOOST_AUTO_TEST_CASE(ConstructTwoAspectWithTwoFeathers)
+{
+  BOOST_FAIL("Not yet implemented");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -12,6 +12,9 @@ const std::string greenData = "08";
 const std::string yellow1Data = "11";
 const std::string yellow2Data = "13";
 
+const std::string feather1Data = "15";
+const std::string feather2Data = "19";
+
 void AddAspect( Lineside::MultiAspectSignalHeadData& mashd,
 		const std::string controller,
 		const Lineside::SignalAspect a,
@@ -59,6 +62,34 @@ Lineside::MultiAspectSignalHeadData MakeFourAspect( const Lineside::ItemId id,
   return mashd;
 }
 
+void AddFeather( Lineside::MultiAspectSignalHeadData& mashd,
+		 const unsigned int featherId,
+		 const std::string controller,
+		 const std::string data ) {
+  Lineside::DeviceRequestData req;
+  req.controller = controller;
+  req.controllerData = data;
+
+  mashd.featherRequests[featherId] = req;;
+}
+		 
+
+Lineside::MultiAspectSignalHeadData MakeTwoAspectOneFeather( const Lineside::ItemId id,
+							     const std::string controller ) {
+  auto mashd = MakeTwoAspect(id, controller);
+  AddFeather(mashd, 1, controller, feather1Data);
+
+  return mashd;
+}
+
+Lineside::MultiAspectSignalHeadData MakeTwoAspectTwoFeather( const Lineside::ItemId id,
+							     const std::string controller ) {
+  auto mashd = MakeTwoAspect(id, controller);
+  AddFeather(mashd, 1, controller, feather1Data);
+  AddFeather(mashd, 2, controller, feather2Data);
+
+  return mashd;
+}
 
 
 // =====================================
@@ -130,10 +161,63 @@ BOOST_AUTO_TEST_CASE(ConstructFourAspect)
 
 BOOST_AUTO_TEST_CASE(ConstructTwoAspectWithOneFeather)
 {
-  BOOST_FAIL("Not yet implemented");
+  const Lineside::ItemId id(16);
+
+  auto mashd = MakeTwoAspectOneFeather( id, this->hwManager->BOPProviderId ); 
+
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  // Ensure we have got the right number of output pins assigned
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.size(), 3 );
+
+  // Check that the right pins were assigned
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(redData), 1 );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(greenData), 1 );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(feather1Data), 1);
 }
 
 BOOST_AUTO_TEST_CASE(ConstructTwoAspectWithTwoFeathers)
+{
+  const Lineside::ItemId id(19);
+
+  auto mashd = MakeTwoAspectTwoFeather( id, this->hwManager->BOPProviderId ); 
+
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  // Ensure we have got the right number of output pins assigned
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.size(), 4 );
+
+  // Check that the right pins were assigned
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(redData), 1 );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(greenData), 1 );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(feather1Data), 1);
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.count(feather2Data), 1);
+}
+
+BOOST_AUTO_TEST_CASE(TwoAspectSetStateThrowsOnBadAspect)
+{
+  BOOST_FAIL("Not yet implemented");
+}
+
+BOOST_AUTO_TEST_CASE(ThreeAspectSetStateThrowsOnBadAspect)
+{
+  BOOST_FAIL("Not yet implemented");
+}
+
+BOOST_AUTO_TEST_CASE(TwoAspectSetStateThrowsOnBadFeather)
+{
+  BOOST_FAIL("Not yet implemented");
+}
+
+BOOST_AUTO_TEST_CASE(TwoAspectOneFeatherSetStateThrowsOnBadFeather)
 {
   BOOST_FAIL("Not yet implemented");
 }

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -604,6 +604,7 @@ BOOST_AUTO_TEST_CASE(OnRunThreeAspectSteady)
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), true );
+  BOOST_CHECK( !resMASH->HaveStateChange() );
 
   // Set to Yellow
   resMASH->SetState( Lineside::SignalState::Yellow, Lineside::SignalFlash::Steady, 0 );
@@ -613,6 +614,7 @@ BOOST_AUTO_TEST_CASE(OnRunThreeAspectSteady)
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), true );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+  BOOST_CHECK( !resMASH->HaveStateChange() );
   
   // Set to Red
   resMASH->SetState( Lineside::SignalState::Red, Lineside::SignalFlash::Steady, 0 );
@@ -622,6 +624,7 @@ BOOST_AUTO_TEST_CASE(OnRunThreeAspectSteady)
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+  BOOST_CHECK( !resMASH->HaveStateChange() );
 }
 
 BOOST_AUTO_TEST_CASE(OnRunFourAspectSteady)
@@ -651,6 +654,7 @@ BOOST_AUTO_TEST_CASE(OnRunFourAspectSteady)
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), true );
+  BOOST_CHECK( !resMASH->HaveStateChange() );
   
   // Set to Double Yellow
   resMASH->SetState( Lineside::SignalState::DoubleYellow, Lineside::SignalFlash::Steady, 0 );
@@ -661,6 +665,7 @@ BOOST_AUTO_TEST_CASE(OnRunFourAspectSteady)
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), true );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), true );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+  BOOST_CHECK( !resMASH->HaveStateChange() );
   
   // Set to Yellow
   resMASH->SetState( Lineside::SignalState::Yellow, Lineside::SignalFlash::Steady, 0 );
@@ -671,6 +676,7 @@ BOOST_AUTO_TEST_CASE(OnRunFourAspectSteady)
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), true );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+  BOOST_CHECK( !resMASH->HaveStateChange() );
   
   // Set to Red
   resMASH->SetState( Lineside::SignalState::Red, Lineside::SignalFlash::Steady, 0 );
@@ -681,6 +687,49 @@ BOOST_AUTO_TEST_CASE(OnRunFourAspectSteady)
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), false );
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+  BOOST_CHECK( !resMASH->HaveStateChange() );
+}
+
+BOOST_AUTO_TEST_CASE( OnRunTwoAspectFlashing )
+{
+  const Lineside::ItemId id(11);
+  
+  auto mashd = MakeTwoAspect( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  resMASH->OnActivate();
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+
+  // Set to Flashing Green
+  resMASH->SetState( Lineside::SignalState::Green, Lineside::SignalFlash::Flashing, 0 );
+  BOOST_CHECK( resMASH->HaveStateChange() );
+
+  // First call should set to on
+  auto sleepTime = resMASH->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), true );
+  BOOST_CHECK( !resMASH->HaveStateChange() );
+
+  // Call again and it should be off
+  sleepTime = resMASH->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+  BOOST_CHECK( !resMASH->HaveStateChange() );
+
+  // And call again, it should be back on
+  sleepTime = resMASH->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), true );
+  BOOST_CHECK( !resMASH->HaveStateChange() );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -5,27 +5,44 @@
 
 #include "mockhardwaremanagerfixture.hpp"
 
+// =====================================
+
+const std::string redData = "07";
+const std::string greenData = "08";
+const std::string yellow1Data = "11";
+const std::string yellow2Data = "13";
+
+void AddAspect( Lineside::MultiAspectSignalHeadData& mashd,
+		const std::string controller,
+		const Lineside::SignalAspect a,
+		const std::string data ) {
+  Lineside::DeviceRequestData req;
+  req.controller = controller;
+  req.controllerData = data;
+
+  mashd.aspectRequests[a] = req;
+}
+
+Lineside::MultiAspectSignalHeadData MakeTwoAspect( const Lineside::ItemId id,
+						   const std::string controller ) {
+  Lineside::MultiAspectSignalHeadData mashd;
+
+  mashd.id = id;
+  AddAspect( mashd, controller, Lineside::SignalAspect::Red, redData );
+  AddAspect( mashd, controller, Lineside::SignalAspect::Green, greenData );
+
+  return mashd;
+}
+
+// =====================================
+
 BOOST_FIXTURE_TEST_SUITE(MultiAspectSignalHead, MockHardwareManagerFixture)
 
 BOOST_AUTO_TEST_CASE(ConstructTwoAspect)
 {
   const Lineside::ItemId id(11);
-  const std::string controller = this->hwManager->BOPProviderId;
-  const std::string redData = "07";
-  const std::string greenData = "08";
 
-  Lineside::DeviceRequestData redRequest;
-  redRequest.controller = controller;
-  redRequest.controllerData = redData;
-
-  Lineside::DeviceRequestData greenRequest;
-  greenRequest.controller = controller;
-  greenRequest.controllerData = greenData;
-
-  Lineside::MultiAspectSignalHeadData mashd;
-  mashd.id = id;
-  mashd.aspectRequests[Lineside::SignalAspect::Red] = redRequest;
-  mashd.aspectRequests[Lineside::SignalAspect::Green] = greenRequest;
+  auto mashd = MakeTwoAspect( id, this->hwManager->BOPProviderId ); 
 
   auto res = mashd.Construct( this->hwManager );
   BOOST_REQUIRE( res );

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -1,0 +1,34 @@
+#include <boost/test/unit_test.hpp>
+
+#include "multiaspectsignalheaddata.hpp"
+#include "multiaspectsignalhead.hpp"
+
+#include "mockhardwaremanagerfixture.hpp"
+
+BOOST_FIXTURE_TEST_SUITE(MultiAspectSignalHead, MockHardwareManagerFixture)
+
+BOOST_AUTO_TEST_CASE(ConstructTwoAspect)
+{
+  const Lineside::ItemId id(11);
+  const std::string controller = this->hwManager->BOPProviderId;
+  const std::string redData = "07";
+  const std::string greenData = "08";
+
+  Lineside::DeviceRequestData redRequest;
+  redRequest.controller = controller;
+  redRequest.controllerData = redData;
+
+  Lineside::DeviceRequestData greenRequest;
+  greenRequest.controller = controller;
+  greenRequest.controllerData = greenData;
+
+  Lineside::MultiAspectSignalHeadData mashd;
+  mashd.id = id;
+  mashd.aspectRequests[Lineside::SignalAspect::Red] = redRequest;
+  mashd.aspectRequests[Lineside::SignalAspect::Green] = greenRequest;
+
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -537,9 +537,132 @@ BOOST_AUTO_TEST_CASE(ShowsRedOnActivateTwoAspectWithFeather)
   BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(feather1Data)->Get(), false );
 }
 
-BOOST_AUTO_TEST_CASE(OnRunDoesSomething)
+BOOST_AUTO_TEST_CASE(OnRunTwoAspectSteady)
 {
-  BOOST_FAIL("Have several of these to write");
+  const Lineside::ItemId id(11);
+  
+  auto mashd = MakeTwoAspect( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  resMASH->OnActivate();
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+
+  // Set to Green
+  resMASH->SetState( Lineside::SignalState::Green, Lineside::SignalFlash::Steady, 0 );
+  BOOST_CHECK( resMASH->HaveStateChange() );
+  
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), true );
+
+  // Setting to Green again should give no change
+  BOOST_CHECK( !resMASH->HaveStateChange() );
+  resMASH->SetState( Lineside::SignalState::Green, Lineside::SignalFlash::Steady, 0 );
+  BOOST_CHECK( !resMASH->HaveStateChange() );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), true );
+  
+  // Set to Red
+  resMASH->SetState( Lineside::SignalState::Red, Lineside::SignalFlash::Steady, 0 );
+  BOOST_CHECK( resMASH->HaveStateChange() );
+  
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+}
+
+BOOST_AUTO_TEST_CASE(OnRunThreeAspectSteady)
+{
+  const Lineside::ItemId id(11);
+  
+  auto mashd = MakeThreeAspect( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  resMASH->OnActivate();
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+
+  // Set to Green
+  resMASH->SetState( Lineside::SignalState::Green, Lineside::SignalFlash::Steady, 0 );
+  BOOST_CHECK( resMASH->HaveStateChange() );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), true );
+
+  // Set to Yellow
+  resMASH->SetState( Lineside::SignalState::Yellow, Lineside::SignalFlash::Steady, 0 );
+  BOOST_CHECK( resMASH->HaveStateChange() );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+  
+  // Set to Red
+  resMASH->SetState( Lineside::SignalState::Red, Lineside::SignalFlash::Steady, 0 );
+  BOOST_CHECK( resMASH->HaveStateChange() );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+}
+
+BOOST_AUTO_TEST_CASE(OnRunFourAspectSteady)
+{
+  const Lineside::ItemId id(11);
+  
+  auto mashd = MakeFourAspect( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  resMASH->OnActivate();
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+
+  // Set to Green
+  resMASH->SetState( Lineside::SignalState::Green, Lineside::SignalFlash::Steady, 0 );
+  BOOST_CHECK( resMASH->HaveStateChange() );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), true );
+  
+  // Set to Double Yellow
+  resMASH->SetState( Lineside::SignalState::DoubleYellow, Lineside::SignalFlash::Steady, 0 );
+  BOOST_CHECK( resMASH->HaveStateChange() );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+  
+  // Set to Yellow
+  resMASH->SetState( Lineside::SignalState::Yellow, Lineside::SignalFlash::Steady, 0 );
+  BOOST_CHECK( resMASH->HaveStateChange() );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+  
+  // Set to Red
+  resMASH->SetState( Lineside::SignalState::Red, Lineside::SignalFlash::Steady, 0 );
+  BOOST_CHECK( resMASH->HaveStateChange() );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow1Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(yellow2Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -5,6 +5,8 @@
 
 #include "mockhardwaremanagerfixture.hpp"
 
+#include "exceptionmessagecheck.hpp"
+
 // =====================================
 
 const std::string redData = "07";
@@ -324,22 +326,125 @@ BOOST_AUTO_TEST_CASE(TwoAspectSetStateWithTwoFeathers)
 
 BOOST_AUTO_TEST_CASE(TwoAspectSetStateThrowsOnBadAspect)
 {
-  BOOST_FAIL("Not yet implemented");
+  const Lineside::ItemId id(11);
+  
+  auto mashd = MakeTwoAspect( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  auto forbiddenStates = std::set<Lineside::SignalState> { Lineside::SignalState::Yellow,
+							   Lineside::SignalState::DoubleYellow };
+  auto checkFlash = std::set<Lineside::SignalFlash> { Lineside::SignalFlash::Steady,
+						      Lineside::SignalFlash::Flashing };
+  const unsigned int feather = 0;
+  for( auto itState=forbiddenStates.begin();
+       itState!=forbiddenStates.end();
+       ++itState ) {
+    for( auto itFlash=checkFlash.begin();
+	 itFlash!=checkFlash.end();
+	 ++itFlash ) {
+      std::stringstream msg;
+      BOOST_CHECK_EXCEPTION( resMASH->SetState( *itState, *itFlash, feather ),
+			     Lineside::InvalidStateException,
+			     GetExceptionMessageChecker<Lineside::InvalidStateException>( msg.str() ));
+    }
+  }
 }
     
 BOOST_AUTO_TEST_CASE(ThreeAspectSetStateThrowsOnBadAspect)
 {
-  BOOST_FAIL("Not yet implemented");
+  const Lineside::ItemId id(16);
+  
+  auto mashd = MakeThreeAspect( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  auto forbiddenStates = std::set<Lineside::SignalState> { Lineside::SignalState::DoubleYellow };
+  auto checkFlash = std::set<Lineside::SignalFlash> { Lineside::SignalFlash::Steady,
+						      Lineside::SignalFlash::Flashing };
+  const unsigned int feather = 0;
+  for( auto itState=forbiddenStates.begin();
+       itState!=forbiddenStates.end();
+       ++itState ) {
+    for( auto itFlash=checkFlash.begin();
+	 itFlash!=checkFlash.end();
+	 ++itFlash ) {
+      std::stringstream msg;
+      BOOST_CHECK_EXCEPTION( resMASH->SetState( *itState, *itFlash, feather ),
+			     Lineside::InvalidStateException,
+			     GetExceptionMessageChecker<Lineside::InvalidStateException>( msg.str() ));
+    }
+  }
 }
 
 BOOST_AUTO_TEST_CASE(TwoAspectSetStateThrowsOnBadFeather)
 {
-  BOOST_FAIL("Not yet implemented");
+  const Lineside::ItemId id(15);
+  
+  auto mashd = MakeTwoAspect( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+
+  auto allowedStates = std::set<Lineside::SignalState> { Lineside::SignalState::Red,
+							 Lineside::SignalState::Green };
+  auto allowedFlash = std::set<Lineside::SignalFlash> { Lineside::SignalFlash::Steady,
+							Lineside::SignalFlash::Flashing };
+  const unsigned int badFeather = 1;
+  for( auto itState=allowedStates.begin();
+       itState!=allowedStates.end();
+       ++itState ) {
+    for( auto itFlash=allowedFlash.begin();
+	 itFlash!=allowedFlash.end();
+	 ++itFlash ) {
+      std::stringstream msg;
+      BOOST_CHECK_EXCEPTION( resMASH->SetState( *itState, *itFlash, badFeather ),
+			     Lineside::InvalidStateException,
+			     GetExceptionMessageChecker<Lineside::InvalidStateException>( msg.str() ));
+    }
+  }
 }
 
 BOOST_AUTO_TEST_CASE(TwoAspectOneFeatherSetStateThrowsOnBadFeather)
 {
-  BOOST_FAIL("Not yet implemented");
+  const Lineside::ItemId id(85);
+  
+  auto mashd = MakeTwoAspectOneFeather( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+  
+  auto allowedStates = std::set<Lineside::SignalState> { Lineside::SignalState::Red,
+							 Lineside::SignalState::Green };
+  auto allowedFlash = std::set<Lineside::SignalFlash> { Lineside::SignalFlash::Steady,
+							Lineside::SignalFlash::Flashing };
+  const unsigned int badFeather = 2;
+  for( auto itState=allowedStates.begin();
+       itState!=allowedStates.end();
+       ++itState ) {
+    for( auto itFlash=allowedFlash.begin();
+	 itFlash!=allowedFlash.end();
+	 ++itFlash ) {
+      std::stringstream msg;
+      BOOST_CHECK_EXCEPTION( resMASH->SetState( *itState, *itFlash, badFeather ),
+			     Lineside::InvalidStateException,
+			     GetExceptionMessageChecker<Lineside::InvalidStateException>( msg.str() ));
+    }
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -831,4 +831,41 @@ BOOST_AUTO_TEST_CASE(OnRunFeatherDoesNotFlash)
   BOOST_CHECK( !resMASH->HaveStateChange() );
 }
 
+BOOST_AUTO_TEST_CASE( OnDeactivateTurnsAllOff )
+{
+  const Lineside::ItemId id(11);
+  
+  auto mashd = MakeTwoAspectTwoFeather( id, this->hwManager->BOPProviderId ); 
+  
+  auto res = mashd.Construct( this->hwManager );
+  BOOST_REQUIRE( res );
+  BOOST_CHECK_EQUAL( res->getId(), id );
+  auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
+  BOOST_REQUIRE( resMASH );
+  
+  resMASH->OnActivate();
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(feather1Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(feather2Data)->Get(), false );
+
+  // Turn on one feather
+  resMASH->SetState( Lineside::SignalState::Green, Lineside::SignalFlash::Steady, 1 );
+  BOOST_CHECK( resMASH->HaveStateChange() );
+  auto sleepTime = resMASH->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(feather1Data)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(feather2Data)->Get(), false );
+  BOOST_CHECK( !resMASH->HaveStateChange() );
+
+  // Deactivate
+  resMASH->OnDeactivate();
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(feather1Data)->Get(), false );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(feather2Data)->Get(), false );
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -1,3 +1,5 @@
+#include <set>
+
 #include <boost/test/unit_test.hpp>
 
 #include "multiaspectsignalheaddata.hpp"

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -348,6 +348,9 @@ BOOST_AUTO_TEST_CASE(TwoAspectSetStateThrowsOnBadAspect)
 	 itFlash!=checkFlash.end();
 	 ++itFlash ) {
       std::stringstream msg;
+      msg << "Invalid state for " << id << ".";
+      msg << " State was: {"
+	  << *itState << "," << *itFlash << "," << feather << "}";
       BOOST_CHECK_EXCEPTION( resMASH->SetState( *itState, *itFlash, feather ),
 			     Lineside::InvalidStateException,
 			     GetExceptionMessageChecker<Lineside::InvalidStateException>( msg.str() ));
@@ -378,6 +381,9 @@ BOOST_AUTO_TEST_CASE(ThreeAspectSetStateThrowsOnBadAspect)
 	 itFlash!=checkFlash.end();
 	 ++itFlash ) {
       std::stringstream msg;
+      msg << "Invalid state for " << id << ".";
+      msg << " State was: {"
+	  << *itState << "," << *itFlash << "," << feather << "}";
       BOOST_CHECK_EXCEPTION( resMASH->SetState( *itState, *itFlash, feather ),
 			     Lineside::InvalidStateException,
 			     GetExceptionMessageChecker<Lineside::InvalidStateException>( msg.str() ));
@@ -409,6 +415,9 @@ BOOST_AUTO_TEST_CASE(TwoAspectSetStateThrowsOnBadFeather)
 	 itFlash!=allowedFlash.end();
 	 ++itFlash ) {
       std::stringstream msg;
+      msg << "Invalid state for " << id << ".";
+      msg << " State was: {"
+	  << *itState << "," << *itFlash << "," << badFeather << "}";
       BOOST_CHECK_EXCEPTION( resMASH->SetState( *itState, *itFlash, badFeather ),
 			     Lineside::InvalidStateException,
 			     GetExceptionMessageChecker<Lineside::InvalidStateException>( msg.str() ));
@@ -440,6 +449,9 @@ BOOST_AUTO_TEST_CASE(TwoAspectOneFeatherSetStateThrowsOnBadFeather)
 	 itFlash!=allowedFlash.end();
 	 ++itFlash ) {
       std::stringstream msg;
+      msg << "Invalid state for " << id << ".";
+      msg << " State was: {"
+	  << *itState << "," << *itFlash << "," << badFeather << "}";
       BOOST_CHECK_EXCEPTION( resMASH->SetState( *itState, *itFlash, badFeather ),
 			     Lineside::InvalidStateException,
 			     GetExceptionMessageChecker<Lineside::InvalidStateException>( msg.str() ));


### PR DESCRIPTION
Adds the concept of a multiple aspect colour light signal. This includes:

- The `MultiAspectSignalHead` class itself
- The associated `MultiAspectSignalHeadData` class
- A set of tests

There is some very basic documentation embedded as well.