### PR TITLE
Add TrackCircuitMonitor

### DIFF
--- a/include/rtcclient.hpp
+++ b/include/rtcclient.hpp
@@ -8,6 +8,7 @@ namespace Lineside {
   public:
     virtual ~RTCClient() {}
 
+    //! Send a message to rail traffic control from a TrackCircuit
     virtual void SendTrackCircuitNotification( const ItemId trackCircuitId,
 					       const bool occupied ) = 0;
   };

--- a/include/trackcircuitmonitor.hpp
+++ b/include/trackcircuitmonitor.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "pwitemmodel.hpp"
+#include "binaryinputpin.hpp"
+#include "rtcclient.hpp"
+
+namespace Lineside {
+  class TrackCircuitMonitorData;
+
+  class TrackCircuitMonitor : public PWItemModel {
+  public:
+    virtual void OnActivate() override;
+
+    virtual void OnDeactivate() override;
+
+    virtual std::chrono::milliseconds OnRun() override;
+
+    virtual bool HaveStateChange() override;
+
+    bool GetState() const;
+  private:
+    friend class TrackCircuitMonitorData;
+
+    TrackCircuitMonitor(const ItemId tcmId) :
+      PWItemModel(tcmId),
+      monitorPin(),
+      rtc() {}
+    
+    std::weak_ptr<BinaryInputPin> monitorPin;
+    std::weak_ptr<RTCClient> rtc;
+  };
+}

--- a/include/trackcircuitmonitor.hpp
+++ b/include/trackcircuitmonitor.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <atomic>
+
+#include "notifiable.hpp"
 #include "pwitemmodel.hpp"
 #include "binaryinputpin.hpp"
 #include "rtcclient.hpp"
@@ -7,7 +10,7 @@
 namespace Lineside {
   class TrackCircuitMonitorData;
 
-  class TrackCircuitMonitor : public PWItemModel {
+  class TrackCircuitMonitor : public PWItemModel, public Notifiable<bool> {
   public:
     virtual void OnActivate() override;
 
@@ -18,14 +21,18 @@ namespace Lineside {
     virtual bool HaveStateChange() override;
 
     bool GetState() const;
+
+    virtual void Notify(const unsigned int sourceId, const bool notification) override;
   private:
     friend class TrackCircuitMonitorData;
 
     TrackCircuitMonitor(const ItemId tcmId) :
       PWItemModel(tcmId),
+      lastNotificationState(false),
       monitorPin(),
       rtc() {}
-    
+
+    std::atomic<bool> lastNotificationState;
     std::weak_ptr<BinaryInputPin> monitorPin;
     std::weak_ptr<RTCClient> rtc;
   };

--- a/include/trackcircuitmonitor.hpp
+++ b/include/trackcircuitmonitor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <mutex>
 
 #include "notifiable.hpp"
 #include "pwitemmodel.hpp"
@@ -10,8 +11,11 @@
 namespace Lineside {
   class TrackCircuitMonitorData;
 
+  //! Class to monitor a track circuit and send notifications to rail traffic control
   class TrackCircuitMonitor : public PWItemModel, public Notifiable<bool> {
   public:
+    const std::chrono::milliseconds SleepRequest = std::chrono::milliseconds(5000);
+    
     virtual void OnActivate() override;
 
     virtual void OnDeactivate() override;
@@ -28,10 +32,12 @@ namespace Lineside {
 
     TrackCircuitMonitor(const ItemId tcmId) :
       PWItemModel(tcmId),
+      updateMtx(),
       lastNotificationState(false),
       monitorPin(),
       rtc() {}
 
+    std::mutex updateMtx;
     std::atomic<bool> lastNotificationState;
     std::weak_ptr<BinaryInputPin> monitorPin;
     std::weak_ptr<RTCClient> rtc;

--- a/include/trackcircuitmonitor.hpp
+++ b/include/trackcircuitmonitor.hpp
@@ -20,12 +20,15 @@ namespace Lineside {
 
     virtual void OnDeactivate() override;
 
+    //! Unconditionally sends an update to rail traffic control
     virtual std::chrono::milliseconds OnRun() override;
 
     virtual bool HaveStateChange() override;
 
+    //! Fetchs the current state of the monitored track circuit
     bool GetState() const;
 
+    //! Method called when the monitored BinaryInputPin changes state
     virtual void Notify(const unsigned int sourceId, const bool notification) override;
   private:
     friend class TrackCircuitMonitorData;

--- a/include/trackcircuitmonitordata.hpp
+++ b/include/trackcircuitmonitordata.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "pwitemdata.hpp"
+#include "devicerequestdata.hpp"
+
+namespace Lineside {
+  class TrackCircuitMonitorData : public PWItemData {
+  public:
+    TrackCircuitMonitorData() :
+      PWItemData(),
+      inputPinRequest() {}
+
+    DeviceRequestData inputPinRequest;
+
+    virtual std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw,
+						    std::shared_ptr<SoftwareManager> sw ) const override;
+  };
+}

--- a/include/trackcircuitmonitordata.hpp
+++ b/include/trackcircuitmonitordata.hpp
@@ -4,6 +4,7 @@
 #include "devicerequestdata.hpp"
 
 namespace Lineside {
+  //! Class to contain data specifying a TrackCircuitMonitor
   class TrackCircuitMonitorData : public PWItemData {
   public:
     TrackCircuitMonitorData() :

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ list(APPEND srcs servoturnoutmotordata.cpp)
 list(APPEND srcs servoturnoutmotor.cpp)
 
 list(APPEND srcs trackcircuitmonitordata.cpp)
+list(APPEND srcs trackcircuitmonitor.cpp)
 
 list(APPEND srcs multiaspectsignalheaddata.cpp)
 list(APPEND srcs multiaspectsignalhead.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,8 @@ list(APPEND srcs pwitemcontroller.cpp)
 list(APPEND srcs servoturnoutmotordata.cpp)
 list(APPEND srcs servoturnoutmotor.cpp)
 
+list(APPEND srcs trackcircuitmonitordata.cpp)
+
 list(APPEND srcs multiaspectsignalheaddata.cpp)
 list(APPEND srcs multiaspectsignalhead.cpp)
 

--- a/src/servoturnoutmotordata.cpp
+++ b/src/servoturnoutmotordata.cpp
@@ -23,7 +23,7 @@ namespace Lineside {
     LOCK_OR_THROW( pwmChannelProvider,
 		   pwmChannelProviderRegistrar->Retrieve(this->pwmChannelRequest.controller) );
     auto servoweak = pwmChannelProvider->GetHardware(this->pwmChannelRequest.controllerData,
-						 this->pwmChannelRequest.settings);
+						     this->pwmChannelRequest.settings);
 
     LOCK_OR_THROW( servo, servoweak );
     

--- a/src/servoturnoutmotordata.cpp
+++ b/src/servoturnoutmotordata.cpp
@@ -24,8 +24,6 @@ namespace Lineside {
 		   pwmChannelProviderRegistrar->Retrieve(this->pwmChannelRequest.controller) );
     auto servoweak = pwmChannelProvider->GetHardware(this->pwmChannelRequest.controllerData,
 						     this->pwmChannelRequest.settings);
-
-    LOCK_OR_THROW( servo, servoweak );
     
     // Work around the private constructor
     struct enabler : public ServoTurnoutMotor {
@@ -36,7 +34,7 @@ namespace Lineside {
     auto result = std::make_shared<enabler>(this->id);
     result->pwmStraight = this->straight;
     result->pwmCurved = this->curved;
-    result->servo = servo;
+    result->servo = servoweak;
 
     return result;
   }

--- a/src/trackcircuitmonitor.cpp
+++ b/src/trackcircuitmonitor.cpp
@@ -1,0 +1,22 @@
+#include "trackcircuitmonitor.hpp"
+
+#include "utility.hpp"
+
+namespace Lineside {
+  void TrackCircuitMonitor::OnActivate() {}
+
+  void TrackCircuitMonitor::OnDeactivate() {}
+
+  std::chrono::milliseconds TrackCircuitMonitor::OnRun() {
+     throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+
+  bool TrackCircuitMonitor::HaveStateChange() {
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+
+  bool TrackCircuitMonitor::GetState() const {
+    LOCK_OR_THROW( bip, this->monitorPin );
+    return bip->Get();
+  }
+}

--- a/src/trackcircuitmonitor.cpp
+++ b/src/trackcircuitmonitor.cpp
@@ -1,3 +1,5 @@
+#include <sstream>
+
 #include "trackcircuitmonitor.hpp"
 
 #include "utility.hpp"
@@ -12,11 +14,26 @@ namespace Lineside {
   }
 
   bool TrackCircuitMonitor::HaveStateChange() {
-    throw std::logic_error(__PRETTY_FUNCTION__);
+    return this->GetState() != this->lastNotificationState;
   }
 
   bool TrackCircuitMonitor::GetState() const {
     LOCK_OR_THROW( bip, this->monitorPin );
     return bip->Get();
+  }
+
+  void TrackCircuitMonitor::Notify(const unsigned int sourceId,
+				   const bool notification) {
+    if( ItemId(sourceId) != this->getId() ) {
+      std::stringstream msg;
+      msg << __PRETTY_FUNCTION__
+	  << " has ItemId mismatch "
+	  << " sourceId=" << ItemId(sourceId)
+	  << " actualId=" << this->getId()
+	  << " with state " << notification;
+      throw std::logic_error(msg.str());
+    }
+
+    this->WakeController();
   }
 }

--- a/src/trackcircuitmonitordata.cpp
+++ b/src/trackcircuitmonitordata.cpp
@@ -1,0 +1,23 @@
+#include "trackcircuitmonitordata.hpp"
+
+#include "utility.hpp"
+
+namespace Lineside {
+  std::shared_ptr<PWItemModel> TrackCircuitMonitorData::Construct( std::shared_ptr<HardwareManager> hw,
+								   std::shared_ptr<SoftwareManager> sw ) const {
+    if( !hw ) {
+      throw std::logic_error("Bad hw ptr");
+    }
+    if( !sw ) {
+      throw std::logic_error("Bad sw ptr");
+    }
+
+    LOCK_OR_THROW( bipProviderRegistrar, hw->GetBIPProviderRegistrar() );
+    LOCK_OR_THROW( bipProvider,
+		   bipProviderRegistrar->Retrieve( this->inputPinRequest.controller ) );
+    auto bipWeak = bipProvider->GetHardware( this->inputPinRequest.controllerData,
+					     this->inputPinRequest.settings );
+    
+    throw std::logic_error(__PRETTY_FUNCTION__);
+  }
+}

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -31,6 +31,8 @@ list(APPEND srcs multiaspectsignalheadtests.cpp)
 
 list(APPEND srcs servoturnoutmotortests.cpp)
 
+list(APPEND srcs trackcircuitmonitortests.cpp)
+
 add_executable( LinesideTest ${srcs} )
 target_include_directories(LinesideTest
   SYSTEM PRIVATE ${Boost_INCLUDE_DIRS})

--- a/tst/trackcircuitmonitortests.cpp
+++ b/tst/trackcircuitmonitortests.cpp
@@ -91,8 +91,68 @@ BOOST_AUTO_TEST_CASE(SetOccupiedUnOccupied)
 
 BOOST_AUTO_TEST_CASE(OnRunSendsToRTC)
 {
-  BOOST_FAIL("Unimplemented");
-}
+  const Lineside::ItemId id(10);
+  const std::string controller = "BIP";
+  const std::string controllerData = "07";
 
+  Lineside::TrackCircuitMonitorData tcmd;
+  tcmd.id = id;
+  tcmd.inputPinRequest.controller = controller;
+  tcmd.inputPinRequest.controllerData = controllerData;
+
+  auto pwItem = tcmd.Construct(this->hwManager, this->swManager);
+  BOOST_REQUIRE( pwItem );
+  BOOST_CHECK_EQUAL( pwItem->getId(), id );
+  auto tcm = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitor>(pwItem);
+  BOOST_REQUIRE( tcm );
+
+  auto mockPWItemController = std::make_shared<MockPWItemController>(id);
+  tcm->RegisterController( tcm->getId().Get(), mockPWItemController );
+  BOOST_CHECK_EQUAL( id, mockPWItemController->expectedId );
+  
+  auto mockBIP = this->hwManager->bipProvider->pins.at(controllerData);
+  BOOST_REQUIRE( mockBIP );
+  BOOST_CHECK_EQUAL( mockBIP->Get(), false );
+  BOOST_CHECK_EQUAL( tcm->GetState(), false );
+
+  BOOST_CHECK_EQUAL( this->swManager->rtcClientList.size(), 1 );
+  auto mockRTC = this->swManager->rtcClientList.at(0);
+  BOOST_CHECK_EQUAL( mockRTC->lastItemId.Get(), 0 );
+
+  // Have TCM send unconditionally
+  auto sleepTime = pwItem->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(5000) );
+  BOOST_CHECK_EQUAL( mockRTC->lastItemId, id );
+  BOOST_CHECK_EQUAL( mockRTC->lastOccupied, false );
+  mockRTC->lastItemId = Lineside::ItemId(0);
+
+  // Check that there's no state change registering
+  BOOST_CHECK_EQUAL( pwItem->HaveStateChange(), false );
+
+  // Set the input to occupied
+  mockBIP->Set(true);
+  BOOST_CHECK_EQUAL( pwItem->HaveStateChange(), true );
+
+  // Send again, will no longer have state change
+  sleepTime = pwItem->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(5000) );
+  BOOST_CHECK_EQUAL( mockRTC->lastItemId, id );
+  BOOST_CHECK_EQUAL( mockRTC->lastOccupied, true );
+  BOOST_CHECK_EQUAL( pwItem->HaveStateChange(), false );
+  mockRTC->lastItemId = Lineside::ItemId(0);
+
+  // Set back to unoccupied
+  mockBIP->Set(false);
+  BOOST_CHECK_EQUAL( pwItem->HaveStateChange(), true );
+
+  
+  // Send again, will no longer have state change
+  sleepTime = pwItem->OnRun();
+  BOOST_CHECK( sleepTime == std::chrono::milliseconds(5000) );
+  BOOST_CHECK_EQUAL( mockRTC->lastItemId, id );
+  BOOST_CHECK_EQUAL( mockRTC->lastOccupied, false );
+  BOOST_CHECK_EQUAL( pwItem->HaveStateChange(), false );
+  mockRTC->lastItemId = Lineside::ItemId(0);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/trackcircuitmonitortests.cpp
+++ b/tst/trackcircuitmonitortests.cpp
@@ -5,6 +5,28 @@
 
 #include "mockmanagerfixture.hpp"
 
+// ======================================
+
+class MockPWItemController : public Lineside::Notifiable<bool> {
+public:
+  MockPWItemController(Lineside::ItemId id) :
+    Notifiable<bool>(),
+    expectedId(id),
+    gotNotification(false) {}
+  
+  virtual void Notify(const unsigned int sourceId,
+		      const bool notification) override {
+    BOOST_CHECK_EQUAL( sourceId, expectedId.Get() );
+    BOOST_CHECK_EQUAL( notification, true ); // Per WakeController()
+    this->gotNotification = true;
+  }
+
+  Lineside::ItemId expectedId;
+  bool gotNotification;
+};
+
+// ======================================
+
 BOOST_FIXTURE_TEST_SUITE(TrackCircuitMonitor, MockManagerFixture)
 
 BOOST_AUTO_TEST_CASE(Construct)
@@ -24,6 +46,53 @@ BOOST_AUTO_TEST_CASE(Construct)
   auto tcm = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitor>(pwItem);
   BOOST_REQUIRE( tcm );
   BOOST_REQUIRE_EQUAL( tcm.use_count(), 2 ); // pwItem and tcm itself
+
+  BOOST_CHECK_EQUAL( this->hwManager->bipProvider->pins.size(), 1 );
+  auto bip = this->hwManager->bipProvider->pins.at(controllerData);
+  BOOST_REQUIRE(bip);
 }
+
+BOOST_AUTO_TEST_CASE(SetOccupiedUnOccupied)
+{
+  const Lineside::ItemId id(10);
+  const std::string controller = "BIP";
+  const std::string controllerData = "07";
+
+  Lineside::TrackCircuitMonitorData tcmd;
+  tcmd.id = id;
+  tcmd.inputPinRequest.controller = controller;
+  tcmd.inputPinRequest.controllerData = controllerData;
+
+  auto pwItem = tcmd.Construct(this->hwManager, this->swManager);
+  BOOST_REQUIRE( pwItem );
+  BOOST_CHECK_EQUAL( pwItem->getId(), id );
+  auto tcm = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitor>(pwItem);
+  BOOST_REQUIRE( tcm );
+
+  auto mockPWItemController = std::make_shared<MockPWItemController>(id);
+  tcm->RegisterController( tcm->getId().Get(), mockPWItemController );
+  BOOST_CHECK_EQUAL( id, mockPWItemController->expectedId );
+  
+  auto mockBIP = this->hwManager->bipProvider->pins.at(controllerData);
+  BOOST_REQUIRE( mockBIP );
+  BOOST_CHECK_EQUAL( mockBIP->Get(), false );
+  BOOST_CHECK_EQUAL( tcm->GetState(), false );
+
+  mockPWItemController->gotNotification = false;
+  mockBIP->Set(true);
+  BOOST_CHECK_EQUAL( tcm->GetState(), true );
+  BOOST_CHECK_EQUAL( mockPWItemController->gotNotification, true );
+
+  mockPWItemController->gotNotification = false;
+  mockBIP->Set(false);
+  BOOST_CHECK_EQUAL( tcm->GetState(), false );
+  BOOST_CHECK_EQUAL( mockPWItemController->gotNotification, true );
+}
+
+BOOST_AUTO_TEST_CASE(OnRunSendsToRTC)
+{
+  BOOST_FAIL("Unimplemented");
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/trackcircuitmonitortests.cpp
+++ b/tst/trackcircuitmonitortests.cpp
@@ -1,0 +1,29 @@
+#include <boost/test/unit_test.hpp>
+
+#include "trackcircuitmonitordata.hpp"
+#include "trackcircuitmonitor.hpp"
+
+#include "mockmanagerfixture.hpp"
+
+BOOST_FIXTURE_TEST_SUITE(TrackCircuitMonitor, MockManagerFixture)
+
+BOOST_AUTO_TEST_CASE(Construct)
+{
+  const Lineside::ItemId id(10);
+  const std::string controller = "BIP";
+  const std::string controllerData = "07";
+
+  Lineside::TrackCircuitMonitorData tcmd;
+  tcmd.id = id;
+  tcmd.inputPinRequest.controller = controller;
+  tcmd.inputPinRequest.controllerData = controllerData;
+
+  auto pwItem = tcmd.Construct(this->hwManager, this->swManager);
+  BOOST_REQUIRE( pwItem );
+  BOOST_CHECK_EQUAL( pwItem->getId(), id );
+  auto tcm = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitor>(pwItem);
+  BOOST_REQUIRE( tcm );
+  BOOST_REQUIRE_EQUAL( tcm.use_count(), 2 ); // pwItem and tcm itself
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add a `TrackCircuitMonitor` class which makes use of a `BinaryInputPin` and sends notifications to rail traffic control.

Includes associated tests.