### PR TITLE
Add 'Parse' concept

### DIFF
--- a/include/parse.hpp
+++ b/include/parse.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+namespace Lineside {
+  //! The concept of parsing
+  /*!
+    There is no actual templated implementation. Individual
+    types must specialise the template for themselves.
+  */
+  template<typename T>
+  T Parse(const std::string& src);
+}

--- a/include/signalaspect.hpp
+++ b/include/signalaspect.hpp
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <string>
 
+#include "parse.hpp"
+
 namespace Lineside {
   enum class SignalAspect { Red,
 			    Yellow1,
@@ -13,4 +15,8 @@ namespace Lineside {
   std::ostream& operator<<( std::ostream& os, const SignalAspect s );
   
   std::string ToString( const SignalAspect s );
+
+  //! Template specialisation to parse a string to a SignalAspect
+  template<>
+  SignalAspect Parse<SignalAspect>(const std::string& src );
 }

--- a/src/signalaspect.cpp
+++ b/src/signalaspect.cpp
@@ -38,4 +38,24 @@ namespace Lineside {
 
     return res;
   }
+
+  template<>
+  SignalAspect Parse<SignalAspect>(const std::string& src) {
+    if( convertor.empty() ) {
+      initconvertor();
+    }
+    
+    try {
+      SignalAspect sa;
+      sa = convertor.right.at(src);
+      return sa;
+    }
+    catch( std::out_of_range& e ) {
+      std::stringstream msg;
+      msg << "Could not parse '";
+      msg << src;
+      msg << "' to SignalAspect";
+      throw std::invalid_argument(msg.str());
+    }
+  }
 }

--- a/tst/signalaspecttests.cpp
+++ b/tst/signalaspecttests.cpp
@@ -29,5 +29,9 @@ BOOST_DATA_TEST_CASE( StreamInsertion, nameToAspectZip, name, aspect )
   BOOST_CHECK_EQUAL( res.str(), name );
 }
 
+BOOST_DATA_TEST_CASE( Parse, nameToAspectZip, name, aspect )
+{
+  BOOST_CHECK_EQUAL( aspect, Lineside::Parse<Lineside::SignalAspect>(name) );
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add a template declaration (but not definition) for parsing strings to objects. Provide a specialisation which implements the template for `SignalAspect` along with a test.