### PR TITLE
Azure Dev Ops Boost fix

### DIFF
--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -9,12 +9,6 @@ parameters:
   makeTarget: ''
 
 steps:
-- script: sudo updatedb
-  displayName: "Enable locate"
-
-- script: locate libboost_filesystem
-  displayName: "Find boost"
-  
 - task: Bash@3
   displayName: "Install xerces library"
   inputs:

--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -3,7 +3,7 @@
 parameters:
   srcDir: ''
   bldDir: ''
-  cmakeArgs: '-DBoost_DEBUG=ON -DBoost_ARCHITECTURE=-x64'
+  cmakeArgs: '-DBoost_DEBUG=ON'
   cmakeExtraArgs: ''
   makeExtraArgs: ''
   makeTarget: ''

--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -9,6 +9,12 @@ parameters:
   makeTarget: ''
 
 steps:
+- script: sudo updatedb
+  displayName: "Enable locate"
+
+- script: locate libboost_filesystem
+  displayName: "Find boost"
+  
 - task: Bash@3
   displayName: "Install xerces library"
   inputs:

--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -3,7 +3,7 @@
 parameters:
   srcDir: ''
   bldDir: ''
-  cmakeArgs: '-DBoost_DEBUG=ON'
+  cmakeArgs: '-DBoost_DEBUG=ON -DBOOST_ROOT=/usr/local/share/boost/1.69.0'
   cmakeExtraArgs: ''
   makeExtraArgs: ''
   makeTarget: ''

--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -3,7 +3,7 @@
 parameters:
   srcDir: ''
   bldDir: ''
-  cmakeArgs: '-DBoost_DEBUG=ON -DBOOST_ROOT=/usr/local/share/boost/1.69.0'
+  cmakeArgs: '-DBoost_DEBUG=ON -DBOOST_ROOT=/usr/local/share/boost/1.69.0 -DBoost_ARCHITECTURE=-x64'
   cmakeExtraArgs: ''
   makeExtraArgs: ''
   makeTarget: ''


### PR DESCRIPTION
It appears that the ADO build agents have stopped setting `BOOST_ROOT`