### PR TITLE
Add SoftwareManagerData

### DIFF
--- a/include/softwaremanagerdata.hpp
+++ b/include/softwaremanagerdata.hpp
@@ -8,6 +8,11 @@ namespace Lineside {
   //! Class to hold data to construct a software manager
   class SoftwareManagerData {
   public:
+    SoftwareManagerData() :
+      rtcAddress("Uninitialised"),
+      rtcPort(0),
+      settings() {}
+    
     std::string rtcAddress;
     uint16_t rtcPort;
     std::map<std::string,std::string> settings;

--- a/include/softwaremanagerdata.hpp
+++ b/include/softwaremanagerdata.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+namespace Lineside {
+  //! Class to hold data to construct a software manager
+  class SoftwareManagerData {
+  public:
+    std::string rtcAddress;
+    uint16_t rcPort;
+    std::map<std::string,std::string> settings;
+  };
+}

--- a/include/softwaremanagerdata.hpp
+++ b/include/softwaremanagerdata.hpp
@@ -9,7 +9,7 @@ namespace Lineside {
   class SoftwareManagerData {
   public:
     std::string rtcAddress;
-    uint16_t rcPort;
+    uint16_t rtcPort;
     std::map<std::string,std::string> settings;
   };
 }

--- a/include/xml/softwaremanagerdatareader.hpp
+++ b/include/xml/softwaremanagerdatareader.hpp
@@ -1,2 +1,22 @@
-#pragman once
+#pragma once
 
+#include <xercesc/dom/DOMElement.hpp>
+
+#include "softwaremanagerdata.hpp"
+
+namespace Lineside {
+  namespace xml {
+    //! Class to read in data to construct the SoftwareManager
+    class SoftwareManagerDataReader {
+    public:
+      const std::string SoftwareManagerElement = "SoftwareManager";
+      const std::string RTCElement = "RTC";
+      
+      bool HasSoftwareManager( const xercesc::DOMElement *parent ) const;
+
+      xercesc::DOMElement* GetSoftwareManagerElement( const xercesc::DOMElement *parent ) const;
+
+      Lineside::SoftwareManagerData Read( const xercesc::DOMElement *softwaremanagerElement ) const;
+    };
+  }
+}

--- a/include/xml/softwaremanagerdatareader.hpp
+++ b/include/xml/softwaremanagerdatareader.hpp
@@ -1,0 +1,2 @@
+#pragman once
+

--- a/src/xml/CMakeLists.txt
+++ b/src/xml/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND srcs servoturnoutmotordatareader.cpp)
 list(APPEND srcs trackcircuitmonitordatareader.cpp)
 list(APPEND srcs multiaspectsignalheaddatareader.cpp)
 list(APPEND srcs pwitemlistreader.cpp)
+list(APPEND srcs softwaremanagerdatareader.cpp)
 
 target_sources( lineside PRIVATE ${srcs} )
 target_include_directories(lineside SYSTEM

--- a/src/xml/softwaremanagerdatareader.cpp
+++ b/src/xml/softwaremanagerdatareader.cpp
@@ -1,0 +1,40 @@
+#include "xml/utilities.hpp"
+
+#include "xml/settingsreader.hpp"
+#include "xml/softwaremanagerdatareader.hpp"
+
+namespace Lineside {
+  namespace xml {
+    bool SoftwareManagerDataReader::HasSoftwareManager( const xercesc::DOMElement *parent ) const {
+      if( !parent ) {
+	throw std::logic_error("Bad parent ptr");
+      }
+
+      return HasChildElement(parent, this->SoftwareManagerElement);
+    }
+
+    xercesc::DOMElement* SoftwareManagerDataReader::GetSoftwareManagerElement( const xercesc::DOMElement *parent ) const {
+      if( !parent ) {
+	throw std::logic_error("Bad parent ptr");
+      }
+
+      auto softwaremanagerElement = Lineside::xml::GetSingleElementByName(parent,
+									  this->SoftwareManagerElement );
+      if( !softwaremanagerElement ) {
+	throw std::logic_error("Bad softwaremanager element");
+      }
+      return softwaremanagerElement;
+    }
+
+    Lineside::SoftwareManagerData SoftwareManagerDataReader::Read( const xercesc::DOMElement *softwaremanagerElement ) const {
+      if( !softwaremanagerElement ) {
+	throw std::logic_error("Bad softwaremanagerElement ptr");
+      }
+
+      Lineside::SoftwareManagerData result;
+
+
+      return result;
+    }
+  }
+}

--- a/src/xml/softwaremanagerdatareader.cpp
+++ b/src/xml/softwaremanagerdatareader.cpp
@@ -1,6 +1,8 @@
-#include "xml/utilities.hpp"
+#include <xercesc/dom/DOMNodeList.hpp>
 
+#include "xml/utilities.hpp"
 #include "xml/settingsreader.hpp"
+
 #include "xml/softwaremanagerdatareader.hpp"
 
 namespace Lineside {
@@ -33,7 +35,30 @@ namespace Lineside {
 
       Lineside::SoftwareManagerData result;
 
+      // Read in the settings
+      SettingsReader sr;
+      if( sr.HasSettings( softwaremanagerElement ) ) {
+	auto settingsElement = sr.GetSettingsElement(softwaremanagerElement);
+	result.settings = sr.Read(settingsElement);
+      }
 
+      // Read in the other elements
+      auto children = softwaremanagerElement->getChildNodes();
+
+      auto TAG_rtc = StrToXMLCh(this->RTCElement);
+      for( XMLSize_t i=0; i<children->getLength(); i++ ) {
+	auto child = children->item(i);
+	if( IsElementNode(child) ) {
+	  auto element = dynamic_cast<xercesc::DOMElement*>(child);
+
+	  // Check for RTC element
+	  if( xercesc::XMLString::equals( element->getTagName(), TAG_rtc.get() ) ) {
+	    result.rtcAddress = GetAttributeByName( element, "address" );
+	    result.rtcPort = std::stoul(GetAttributeByName( element, "port" ));
+	  } 
+	}
+      }
+	
       return result;
     }
   }

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -39,7 +39,7 @@ list(APPEND srcs settingsreadertests.cpp)
 list(APPEND srcs devicerequestdatatests.cpp)
 list(APPEND srcs pwitemdatareadertests.cpp)
 list(APPEND srcs pwitemlistreadertests.cpp)
-list(APPEND srcs softwaredatamanagerreadertests.cpp)
+list(APPEND srcs softwaremanagerdatareadertests.cpp)
 
 list(APPEND srcs pwitemmanagertests.cpp)
 

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -39,6 +39,7 @@ list(APPEND srcs settingsreadertests.cpp)
 list(APPEND srcs devicerequestdatatests.cpp)
 list(APPEND srcs pwitemdatareadertests.cpp)
 list(APPEND srcs pwitemlistreadertests.cpp)
+list(APPEND srcs softwaredatamanagerreadertests.cpp)
 
 list(APPEND srcs pwitemmanagertests.cpp)
 

--- a/tst/softwaremanagerdatareadertests.cpp
+++ b/tst/softwaremanagerdatareadertests.cpp
@@ -24,6 +24,15 @@ BOOST_AUTO_TEST_CASE( SmokeReader )
 
   auto rootElement = GetRootElementOfFile(parser, softwaremanagerdataFragment);
   BOOST_REQUIRE(rootElement);
+
+  Lineside::xml::SoftwareManagerDataReader reader;
+  BOOST_REQUIRE( reader.HasSoftwareManager(rootElement) );
+  auto softwareManagerElement = reader.GetSoftwareManagerElement(rootElement);
+  auto result = reader.Read(softwareManagerElement);
+  BOOST_CHECK_EQUAL( result.rtcAddress, "addr" );
+  BOOST_CHECK_EQUAL( result.rtcPort, 8080 );
+  BOOST_REQUIRE_EQUAL( result.settings.size(), 1 );
+  BOOST_CHECK_EQUAL( result.settings.at("a"), "c" );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/softwaremanagerdatareadertests.cpp
+++ b/tst/softwaremanagerdatareadertests.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE( SmokeReader )
   BOOST_CHECK_EQUAL( result.rtcAddress, "addr" );
   BOOST_CHECK_EQUAL( result.rtcPort, 8080 );
   BOOST_REQUIRE_EQUAL( result.settings.size(), 1 );
-  BOOST_CHECK_EQUAL( result.settings.at("a"), "c" );
+  BOOST_CHECK_EQUAL( result.settings.at("a"), "b" );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/softwaremanagerdatareadertests.cpp
+++ b/tst/softwaremanagerdatareadertests.cpp
@@ -1,0 +1,29 @@
+#include <boost/test/unit_test.hpp>
+
+#include <xercesc/parsers/XercesDOMParser.hpp>
+
+#include "xmlutils.hpp"
+
+#include "xml/xercesguard.hpp"
+#include "xml/utilities.hpp"
+
+#include "xml/softwaremanagerdatareader.hpp"
+
+// ==============
+
+const std::string softwaremanagerdataFragment = "softwaremanagerdata-fragment.xml";
+
+// ==============
+
+BOOST_AUTO_TEST_SUITE( SoftwareManagerDataReader )
+
+BOOST_AUTO_TEST_CASE( SmokeReader )
+{
+  Lineside::xml::XercesGuard xg;
+  auto parser = GetParser();
+
+  auto rootElement = GetRootElementOfFile(parser, softwaremanagerdataFragment);
+  BOOST_REQUIRE(rootElement);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/xmlsamples/CMakeLists.txt
+++ b/tst/xmlsamples/CMakeLists.txt
@@ -10,3 +10,5 @@ configure_file(pwitem-trackcircuitmonitor.xml . COPYONLY)
 configure_file(pwitem-multiaspectsignalhead.xml . COPYONLY)
 
 configure_file(pwitemlist.xml . COPYONLY)
+
+configure_file(softwaremanagerdata-fragment.xml . COPYONLY)

--- a/tst/xmlsamples/softwaremanagerdata-fragment.xml
+++ b/tst/xmlsamples/softwaremanagerdata-fragment.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Test>
+  <SoftwareManager>
+    <RTC address="addr" port="8080" />
+    <Settings>
+      <Setting key="a" value="b" />
+    </Settings>
+  </SoftwareManager>
+</Test>


### PR DESCRIPTION
The `SoftwareManagerData` class defines the data to be read from the XML configuration for configuring the `SoftwareManager`. This is read by the `SoftwareManagerDataReader` from the XML file.

Includes smoke test of the functionality.