### PR TITLE
Add DeviceRequestException

### DIFF
--- a/include/linesideexceptions.hpp
+++ b/include/linesideexceptions.hpp
@@ -87,6 +87,43 @@ namespace Lineside {
 
   // ========================================
 
+  //! Exception for improper hardware requests
+  /*!
+    Hardware manager implementations throw this
+    when unable to satisfy a device request
+   */
+  class DeviceRequestException : public LinesideException {
+  public:
+    explicit DeviceRequestException(const std::string ctrl,
+				    const std::string ctrlData,
+				    const std::string issue) :
+      LinesideException(""),
+      controller(ctrl),
+      controllerData(ctrlData),
+      issueDescription(issue),
+      message() {
+      std::stringstream tmp;
+      tmp << "Bad Device Request for controller "
+	  << this->controller
+	  << " with controllerData "
+	  << this->controllerData;
+      tmp << ". Issue: "
+	  << this->issueDescription;
+      this->message = tmp.str();
+    }
+
+    const std::string controller;
+    const std::string controllerData;
+    const std::string issueDescription;
+    std::string message;
+
+    virtual const char* what() const noexcept override {
+      return this->message.c_str();
+    }
+  };
+  
+  // ========================================
+
   //! Base exception for problems with maps
   /*!
     This exception class is provided to allow

--- a/tst/exceptiontests.cpp
+++ b/tst/exceptiontests.cpp
@@ -38,6 +38,20 @@ BOOST_AUTO_TEST_CASE(BadPWItemDataException)
   BOOST_CHECK_EQUAL( expected, bpde.what() );
 }
 
+BOOST_AUTO_TEST_CASE(DeviceRequestException)
+{
+  const std::string ctrl("A");
+  const std::string ctrlData("BC");
+  const std::string issue("DEF");
+
+  Lineside::DeviceRequestException dre(ctrl, ctrlData, issue);
+  BOOST_CHECK_EQUAL( dre.controller, ctrl );
+  BOOST_CHECK_EQUAL( dre.controllerData, ctrlData );
+  BOOST_CHECK_EQUAL( dre.issueDescription, issue );
+  const std::string expected = "Something";
+  BOOST_CHECK_EQUAL( expected, dre.what() );
+}
+
 BOOST_AUTO_TEST_CASE(KeyNotFoundException)
 {
   Lineside::KeyNotFoundException knfe("myKey");

--- a/tst/exceptiontests.cpp
+++ b/tst/exceptiontests.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(DeviceRequestException)
   BOOST_CHECK_EQUAL( dre.controller, ctrl );
   BOOST_CHECK_EQUAL( dre.controllerData, ctrlData );
   BOOST_CHECK_EQUAL( dre.issueDescription, issue );
-  const std::string expected = "Something";
+  const std::string expected = "Bad Device Request for controller A with controllerData BC. Issue: DEF";
   BOOST_CHECK_EQUAL( expected, dre.what() );
 }
 


### PR DESCRIPTION
Add an exception for hardware managers to throw when they are unable to satisfy a request (such as when an output pin has already been assigned elsewhere). Includes a test of the exception itself.