### PR TITLE
Add ConfigurationReader

### DIFF
--- a/include/configurationdata.hpp
+++ b/include/configurationdata.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <vector>
+#include <memory>
+
+#include "softwaremanagerdata.hpp"
+#include "hardwaremanagerdata.hpp"
+#include "pwitemdata.hpp"
+
+namespace Lineside {
+  //! Class to hold all configuration data
+  class ConfigurationData {
+  public:
+    ConfigurationData() :
+      swManager(),
+      hwManager(),
+      pwItems() {}
+    
+    SoftwareManagerData swManager;
+
+    HardwareManagerData hwManager;
+
+    std::vector<std::shared_ptr<PWItemData>> pwItems;
+  };
+}

--- a/include/xml/configurationreader.hpp
+++ b/include/xml/configurationreader.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+
+#include "configurationdata.hpp"
+
+#include "xml/xercesguard.hpp"
+
+namespace Lineside {
+  namespace xml {
+    //! Class to handle reading in the XML file
+    class ConfigurationReader {
+    public:
+      const std::string LinesideCabinetElement = std::string("LinesideCabinet");
+      
+      ConfigurationReader() :
+	libraryGuard() {}
+
+      ConfigurationData Read( const std::string filePath ) const;
+    private:
+      XercesGuard libraryGuard;
+    };
+  }
+}

--- a/src/xml/CMakeLists.txt
+++ b/src/xml/CMakeLists.txt
@@ -16,6 +16,8 @@ list(APPEND srcs i2cdevicedatareader.cpp)
 list(APPEND srcs i2cdevicelistreader.cpp)
 list(APPEND srcs hardwaremanagerdatareader.cpp)
 
+list(APPEND srcs configurationreader.cpp)
+
 target_sources( lineside PRIVATE ${srcs} )
 target_include_directories(lineside SYSTEM
   PUBLIC ${XercesC_INCLUDE_DIRS})

--- a/src/xml/configurationreader.cpp
+++ b/src/xml/configurationreader.cpp
@@ -1,0 +1,15 @@
+#include "xml/configurationreader.hpp"
+
+namespace Lineside {
+  namespace xml {
+    ConfigurationData ConfigurationReader::Read( const std::string filePath ) const {
+      if( filePath.empty() ) {
+	throw std::logic_error("Empty filePath");
+      }
+      
+      ConfigurationData result;
+
+      return result;
+    }
+  }
+}

--- a/src/xml/configurationreader.cpp
+++ b/src/xml/configurationreader.cpp
@@ -1,3 +1,13 @@
+#include <stdexcept>
+
+#include <xercesc/parsers/XercesDOMParser.hpp>
+
+#include "xml/utilities.hpp"
+
+#include "xml/softwaremanagerdatareader.hpp"
+#include "xml/hardwaremanagerdatareader.hpp"
+#include "xml/pwitemlistreader.hpp"
+
 #include "xml/configurationreader.hpp"
 
 namespace Lineside {
@@ -6,9 +16,39 @@ namespace Lineside {
       if( filePath.empty() ) {
 	throw std::logic_error("Empty filePath");
       }
+
+      // Set up the parser
+      xercesc::XercesDOMParser parser;
+      parser.setValidationScheme( xercesc::XercesDOMParser::Val_Never );
+      parser.setDoNamespaces( false );
+      parser.setDoSchema( false );
+      parser.setLoadExternalDTD( false );
+
+      // Read the file into Xerces
+      parser.parse( filePath.c_str() );
+
+      // Get the root element
+      auto xmlDoc = parser.getDocument();
+      auto rootElement = xmlDoc->getDocumentElement();
+      if( !rootElement ) {
+	throw std::logic_error("Could not get root element of document");
+      }
+
+      if( !xercesc::XMLString::equals(rootElement->getTagName(),
+				      Lineside::xml::StrToXMLCh(this->LinesideCabinetElement).get() ) ) {
+	throw std::logic_error("Bad name for root element");
+      }
+
+      SoftwareManagerDataReader swReader;
+      HardwareManagerDataReader hwReader;
+      PWItemListReader pwItemReader;
       
       ConfigurationData result;
 
+      result.swManager = swReader.Read( swReader.GetSoftwareManagerElement( rootElement ) );
+      result.hwManager = hwReader.Read( hwReader.GetHardwareManagerElement( rootElement ) );
+      result.pwItems = pwItemReader.Read( pwItemReader.GetPWItemListElement( rootElement ) );
+      
       return result;
     }
   }

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND srcs softwaremanagerdatareadertests.cpp)
 list(APPEND srcs i2cdevicedatareadertests.cpp)
 list(APPEND srcs i2cdevicelistreadertests.cpp)
 list(APPEND srcs hardwaremanagerdatareadertests.cpp)
+list(APPEND srcs configurationreadertests.cpp)
 
 list(APPEND srcs pwitemmanagertests.cpp)
 

--- a/tst/configurationreadertests.cpp
+++ b/tst/configurationreadertests.cpp
@@ -4,6 +4,8 @@
 
 #include "xml/configurationreader.hpp"
 
+#include "trackcircuitmonitordata.hpp"
+
 // ==============
 
 const std::string configurationFile = "full-configuration-sample.xml";
@@ -20,7 +22,35 @@ BOOST_AUTO_TEST_CASE( SmokeReader )
   
   auto res = reader.Read( fullPath );
 
+  // Check the software manager
+  BOOST_CHECK_EQUAL( res.swManager.rtcAddress, "addr" );
+  BOOST_CHECK_EQUAL( res.swManager.rtcPort, 8081 );
+  BOOST_REQUIRE_EQUAL( res.swManager.settings.size(), 1 );
+  BOOST_CHECK_EQUAL( res.swManager.settings.at("aKey"), "bValue" );
+
+  // Check the hardware manager
+  BOOST_REQUIRE_EQUAL( res.hwManager.i2cDevices.size(), 1 );
+  auto dev0 = res.hwManager.i2cDevices.at(0);
+  BOOST_CHECK_EQUAL( dev0.kind, "pca9685" );
+  BOOST_CHECK_EQUAL( dev0.bus, 0 );
+  BOOST_CHECK_EQUAL( dev0.address, 0x0F );
+  BOOST_CHECK_EQUAL( dev0.name, "pwm0" );
+
+  BOOST_REQUIRE_EQUAL( res.hwManager.settings.size(), 1 );
+  BOOST_CHECK_EQUAL( res.hwManager.settings.at("some"), "thing" );
+
+  // Check the list of PWItems
   BOOST_REQUIRE_EQUAL( res.pwItems.size(), 1 );
+  auto item0 = res.pwItems.at(0);
+  auto tcmd0 = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitorData>(item0);
+  BOOST_REQUIRE( tcmd0 );
+  Lineside::ItemId expectedId;
+  expectedId.Parse("10:fe:02:1a");
+  BOOST_CHECK_EQUAL( tcmd0->id, expectedId );
+  BOOST_CHECK_EQUAL( tcmd0->inputPinRequest.controller, "GPIO" );
+  BOOST_CHECK_EQUAL( tcmd0->inputPinRequest.controllerData, "07" );
+  BOOST_REQUIRE_EQUAL( tcmd0->inputPinRequest.settings.size(), 1 );
+  BOOST_CHECK_EQUAL( tcmd0->inputPinRequest.settings.at("glitch"), "20000" );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/configurationreadertests.cpp
+++ b/tst/configurationreadertests.cpp
@@ -12,7 +12,7 @@ const std::string configurationFile = "full-configuration-sample.xml";
 
 // ==============
 
-BOOST_AUTO_TEST_SUITE( ConfigurationReaderTests )
+BOOST_AUTO_TEST_SUITE( ConfigurationReader )
 
 BOOST_AUTO_TEST_CASE( SmokeReader )
 {

--- a/tst/configurationreadertests.cpp
+++ b/tst/configurationreadertests.cpp
@@ -1,0 +1,26 @@
+#include <boost/test/unit_test.hpp>
+
+#include "xmlutils.hpp"
+
+#include "xml/configurationreader.hpp"
+
+// ==============
+
+const std::string configurationFile = "full-configuration-sample.xml";
+
+// ==============
+
+BOOST_AUTO_TEST_SUITE( ConfigurationReaderTests )
+
+BOOST_AUTO_TEST_CASE( SmokeReader )
+{
+  Lineside::xml::ConfigurationReader reader;
+
+  auto fullPath = GetPathToSampleXML( configurationFile );
+  
+  auto res = reader.Read( fullPath );
+
+  BOOST_REQUIRE_EQUAL( res.pwItems.size(), 1 );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/xmlsamples/CMakeLists.txt
+++ b/tst/xmlsamples/CMakeLists.txt
@@ -16,3 +16,5 @@ configure_file(softwaremanagerdata-fragment.xml . COPYONLY)
 configure_file(i2cdevice-fragment.xml . COPYONLY)
 configure_file(i2cdevicelist-fragment.xml . COPYONLY)
 configure_file(hardwaremanager-fragment.xml . COPYONLY)
+
+configure_file(full-configuration-sample.xml . COPYONLY)

--- a/tst/xmlsamples/full-configuration-sample.xml
+++ b/tst/xmlsamples/full-configuration-sample.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<LinesideCabinet>
+  <SoftwareManager>
+    <RTC address="addr" port="8081" />
+    <Settings>
+      <Setting key="aKey" value="bValue" />
+    </Settings>
+  </SoftwareManager>
+  <HardwareManager>
+    <I2CDevices>
+      <I2CDevice kind="pca9685" bus="0" address="0x0F" name="pwm0" />
+    </I2CDevices>
+    <Settings>
+      <Setting key="some" value="thing" />
+    </Settings>
+  </HardwareManager>
+  <PermanentWayItems>
+    <TrackCircuitMonitor id="10:fe:02:1a">
+      <BinaryInput controller="GPIO" controllerData="07">
+	<Settings>
+	  <Setting key="glitch" value="20000" />
+	</Settings>
+      </BinaryInput>
+    </TrackCircuitMonitor>
+  </PermanentWayItems>
+</LinesideCabinet>

--- a/tst/xmlutils.cpp
+++ b/tst/xmlutils.cpp
@@ -17,14 +17,9 @@ std::shared_ptr<xercesc::XercesDOMParser> GetParser() {
   return parser;
 }
 
-xercesc::DOMElement* GetRootElementOfFile(std::shared_ptr<xercesc::XercesDOMParser> parser,
-					  const std::string filename) {
-  /*
-    Opens the designated file in the xmlSampleDir, and returns
-    a pointer to the root element
-  */
-  
-  // Figure out the location of the sample files
+
+std::string GetPathToSampleXML( const std::string filename ) {
+   // Figure out the location of the sample files
   boost::filesystem::path binaryPath(boost::unit_test::framework::master_test_suite().argv[0]);
   boost::filesystem::path p( boost::filesystem::absolute(binaryPath).parent_path() );
   p /= xmlSampleDir;
@@ -34,8 +29,19 @@ xercesc::DOMElement* GetRootElementOfFile(std::shared_ptr<xercesc::XercesDOMPars
   BOOST_TEST_MESSAGE( p.c_str() );
   BOOST_REQUIRE( boost::filesystem::exists(p) );
 
+  return p.native();
+}
+
+xercesc::DOMElement* GetRootElementOfFile(std::shared_ptr<xercesc::XercesDOMParser> parser,
+					  const std::string filename) {
+  /*
+    Opens the designated file in the xmlSampleDir, and returns
+    a pointer to the root element
+  */
+
+
   // Load in the file
-  parser->parse( p.c_str() );
+  parser->parse( GetPathToSampleXML( filename ).c_str() );
 
    // Get the root element
   auto TAG_Test = Lineside::xml::StrToXMLCh("Test");

--- a/tst/xmlutils.hpp
+++ b/tst/xmlutils.hpp
@@ -1,6 +1,9 @@
 #include <memory>
+#include <string>
 
 #include <xercesc/parsers/XercesDOMParser.hpp>
+
+std::string GetPathToSampleXML( const std::string filename );
 
 std::shared_ptr<xercesc::XercesDOMParser> GetParser();
 


### PR DESCRIPTION
Add the `ConfigurationReader` class, which reads an entire configuration file. Note that this class fully encapsulates the Xerces library.

This does not use a schema, since we have not yet created one.