### PR TITLE
Start work on pigpiod integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project("Lineside Cabinet"
 enable_testing()
 
 # --------
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake_modules" ${CMAKE_MODULE_PATH})
 
 find_package(Boost REQUIRED COMPONENTS filesystem system program_options)
 
@@ -14,12 +15,19 @@ find_package(Doxygen)
 
 find_package(XercesC REQUIRED)
 
+find_package(pigpio)
+
 # --------
 
 # Configure the language standard
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Handle pigpiod
+if( pigpio_FOUND )
+  add_compile_options("-DHAVE_PIGPIO")
+endif()
 
 # Warning options for the compiler
 string(

--- a/cmake_modules/Findpigpio.cmake
+++ b/cmake_modules/Findpigpio.cmake
@@ -1,0 +1,34 @@
+################################################################################
+### Find the pigpio shared libraries.
+################################################################################
+
+# Downloaded from:
+# https://raw.githubusercontent.com/joan2937/pigpio/master/util/Findpigpio.cmake
+
+# Find the path to the pigpio includes.
+find_path(pigpio_INCLUDE_DIR 
+	NAMES pigpio.h pigpiod_if.h pigpiod_if2.h
+	HINTS /usr/local/include)
+	
+# Find the pigpio libraries.
+find_library(pigpio_LIBRARY 
+	NAMES libpigpio.so
+	HINTS /usr/local/lib)
+find_library(pigpiod_if_LIBRARY 
+	NAMES libpigpiod_if.so
+	HINTS /usr/local/lib)
+find_library(pigpiod_if2_LIBRARY 
+	NAMES libpigpiod_if2.so
+	HINTS /usr/local/lib)
+    
+# Set the pigpio variables to plural form to make them accessible for 
+# the paramount cmake modules.
+set(pigpio_INCLUDE_DIRS ${pigpio_INCLUDE_DIR})
+set(pigpio_INCLUDES     ${pigpio_INCLUDE_DIR})
+
+# Handle REQUIRED, QUIET, and version arguments 
+# and set the <packagename>_FOUND variable.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(pigpio 
+    DEFAULT_MSG 
+    pigpio_INCLUDE_DIR pigpio_LIBRARY pigpiod_if_LIBRARY pigpiod_if2_LIBRARY)

--- a/include/pigpiod/librarymanager.hpp
+++ b/include/pigpiod/librarymanager.hpp
@@ -1,0 +1,21 @@
+#include <memory>
+#include <mutex>
+
+namespace Lineside {
+  namespace PiGPIOd {
+    //! Class to wrap the pigpiod library
+    class LibraryManager {
+    public:
+      ~LibraryManager();
+      
+      static std::shared_ptr<LibraryManager> CreateLibraryManager();
+    private:
+      LibraryManager();
+
+      int id;
+
+      static bool initialised;
+      static std::mutex mtx;
+    };
+  }
+}

--- a/include/pigpiod/librarymanager.hpp
+++ b/include/pigpiod/librarymanager.hpp
@@ -3,18 +3,56 @@
 
 namespace Lineside {
   namespace PiGPIOd {
-    //! Class to wrap the pigpiod library
+    //! Class to wrap the <a href="http://abyz.me.uk/rpi/pigpio/pigpiod.html">pigpiod library</a>
+    /*!
+      This class is used to manage the calls to
+      <a href="http://abyz.me.uk/rpi/pigpio/pdif2.html#pigpio_start">`pigio_start()`</a>
+      and
+      <a href="http://abyz.me.uk/rpi/pigpio/pdif2.html#pigpio_stop">`pigio_stop()`</a>
+      in the
+      <a href="http://abyz.me.uk/rpi/pigpio/pigpiod.html">pigpiod library</a>.
+      
+      A program wishing to access the pigpiod library should call the static method
+      LibraryManager::CreateLibraryManager
+      which returns a std::shared_ptr to an instance of a LibraryManager object.
+      Copies of this std::shared_ptr can be given to other objects which want to interact
+      with the Raspberry Pi.
+      So long as at least one of these std::shared_ptr objects continues to exist, the
+      pigpiod library will remain active.
+      When the reference count of the std::shared_ptr reaches zero,
+      <a href="http://abyz.me.uk/rpi/pigpio/pdif2.html#pigpio_stop">`pigio_stop()`</a>
+      will be called to stop the library.
+      
+      This class relies on
+      <a href="https://en.cppreference.com/w/cpp/memory/shared_ptr">
+      the control block (which includes the reference count)
+      </a>
+      being thread safe, so that the destructor will be called exactly
+      once (and that there isn't a race condition which can result in an
+      attempted resurrection once the reference count gets to zero).
+     */
     class LibraryManager {
     public:
       ~LibraryManager();
-      
+
+      //! Create an instance of LibraryManager
+      /*!
+	This creates an instance of a LibraryManager object in a std::shared_ptr and
+	returns it.
+	If the library has already been initialised, this will throw a std::logic_error
+	exception.
+       */
       static std::shared_ptr<LibraryManager> CreateLibraryManager();
     private:
       LibraryManager();
 
+      //! The id of the Pi we are accessing (for use in other calls to the pigpiod library)
       int id;
 
+      //! Indicates if the library has been initialised
       static bool initialised;
+
+      //! Mutex to make operations thread safe
       static std::mutex mtx;
     };
   }

--- a/include/pigpiod/pigpiodstubs.hpp
+++ b/include/pigpiod/pigpiodstubs.hpp
@@ -2,6 +2,11 @@
  * Stubs for use on a machine without PiGPIOd
  */
 
+#include <iostream>
+
+//! Stream to be used for output from the stubs (default std::cout)
+extern std::ostream* pigpiodOS;
+
 #ifdef HAVE_PIGPIO
 #error "The real pigpiod library is available. Do not use stubs"
 #endif

--- a/include/pigpiod/pigpiodstubs.hpp
+++ b/include/pigpiod/pigpiodstubs.hpp
@@ -1,0 +1,19 @@
+/** \file
+ * Stubs for use on a machine without PiGPIOd
+ */
+
+#ifdef HAVE_PIGPIO
+#error "The real pigpiod library is available. Do not use stubs"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  int pigpio_start(char *addrStr, char *portStr);
+
+  void pigpio_stop(int pi);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,3 +28,4 @@ target_include_directories(lineside SYSTEM
   PRIVATE ${Boost_INCLUDE_DIRS})
 
 add_subdirectory(xml)
+add_subdirectory(pigpiod)

--- a/src/pigpiod/CMakeLists.txt
+++ b/src/pigpiod/CMakeLists.txt
@@ -4,6 +4,8 @@ if( NOT pigpio_FOUND )
   list(APPEND srcs pigpiodstubs.cpp)
 endif()
 
+list(APPEND srcs librarymanager.cpp)
+
 target_sources( lineside PRIVATE ${srcs} )
 
 if( pigpio_FOUND )

--- a/src/pigpiod/CMakeLists.txt
+++ b/src/pigpiod/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(srcs)
+
+if( NOT pigpio_FOUND )
+  list(APPEND srcs pigpiodstubs.cpp)
+endif()
+
+target_sources( lineside PRIVATE ${srcs} )
+
+if( pigpio_FOUND )
+  target_include_directories(lineside SYSTEM
+    PRIVATE ${pigpio_INCLUDE_DIR})
+  target_link_libraries(lineside PRIVATE ${pigpiod_if2_LIBRARY})
+endif()

--- a/src/pigpiod/librarymanager.cpp
+++ b/src/pigpiod/librarymanager.cpp
@@ -1,0 +1,52 @@
+#include <mutex>
+#include <stdexcept>
+#include <sstream>
+
+#ifdef HAVE_PIGPIO
+#include <pigpiod_if2.h>
+#else
+#include "pigpiod/pigpiodstubs.hpp"
+#endif
+
+#include "pigpiod/librarymanager.hpp"
+
+namespace Lineside {
+  namespace PiGPIOd {
+    std::mutex LibraryManager::mtx;
+    bool LibraryManager::initialised = false;
+
+    LibraryManager::LibraryManager() : id(-1) {
+      this->id = pigpio_start(nullptr, nullptr);
+      if( this->id < 0 ) {
+	std::stringstream msg;
+	msg << "Could not connect to pigpiod."
+	    << "Have you run 'sudo pigpiod' ?";
+	throw std::logic_error(msg.str());
+      }
+    }
+
+    LibraryManager::~LibraryManager() {
+      pigpio_stop(this->id);
+      this->id = -1;
+    }
+
+    std::shared_ptr<LibraryManager> LibraryManager::CreateLibraryManager() {
+      std::lock_guard<std::mutex> lck(LibraryManager::mtx);
+
+      if( LibraryManager::initialised ) {
+	std::stringstream msg;
+	msg << __FUNCTION__
+	    << ": Already initialised";
+	throw std::logic_error(msg.str());
+      }
+
+      // Work around private constructor
+      struct enabler : public LibraryManager {};
+      
+      auto result = std::make_shared<enabler>();
+      LibraryManager::initialised  = true;
+
+      return result;
+    }
+  }
+}

--- a/src/pigpiod/librarymanager.cpp
+++ b/src/pigpiod/librarymanager.cpp
@@ -28,6 +28,7 @@ namespace Lineside {
     LibraryManager::~LibraryManager() {
       pigpio_stop(this->id);
       this->id = -1;
+      LibraryManager::initialised = false;
     }
 
     std::shared_ptr<LibraryManager> LibraryManager::CreateLibraryManager() {

--- a/src/pigpiod/pigpiodstubs.cpp
+++ b/src/pigpiod/pigpiodstubs.cpp
@@ -1,23 +1,22 @@
-#include <iostream>
 #include <stdexcept>
 
 #include "pigpiod/pigpiodstubs.hpp"
 
 const int piId = 0;
 
-static std::ostream* os = &std::cout;
+std::ostream* pigpiodOS = &std::cout;
 
 static bool libraryInitialised = false;
 
 int pigpio_start(char *addrStr, char *portStr) {
-  (*os) << __FUNCTION__;
+  (*pigpiodOS) << __FUNCTION__;
   if( addrStr ) {
-    (*os) << " " << addrStr;
+    (*pigpiodOS) << " " << addrStr;
   }
   if( portStr ) {
-    (*os) << " " << portStr;
+    (*pigpiodOS) << " " << portStr;
   }
-  (*os) << std::endl;
+  (*pigpiodOS) << std::endl;
 
   if( libraryInitialised ) {
     throw std::logic_error("Library already initialised");
@@ -29,7 +28,7 @@ int pigpio_start(char *addrStr, char *portStr) {
 }
 
 void pigpio_stop(int pi) {
-  (*os) << __FUNCTION__ << std::endl;
+  (*pigpiodOS) << __FUNCTION__ << std::endl;
   if( piId != pi ) {
     throw std::logic_error("Bad pi");
   }

--- a/src/pigpiod/pigpiodstubs.cpp
+++ b/src/pigpiod/pigpiodstubs.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+#include <stdexcept>
+
+#include "pigpiod/pigpiodstubs.hpp"
+
+const int piId = 0;
+
+static bool libraryInitialised = false;
+
+int pigpio_start(char *addrStr, char *portStr) {
+  std::cout << __FUNCTION__;
+  std::cout << ": " << addrStr;
+  std::cout << " " << portStr;
+  std::cout << std::endl;
+
+  if( libraryInitialised ) {
+    throw std::logic_error("Library already initialised");
+  }
+  
+  libraryInitialised = true;
+  
+  return piId;
+}
+
+void pigpio_stop(int pi) {
+  std::cout << __FUNCTION__ << std::endl;
+  if( piId != pi ) {
+    throw std::logic_error("Bad pi");
+  }
+  libraryInitialised = false;
+}

--- a/src/pigpiod/pigpiodstubs.cpp
+++ b/src/pigpiod/pigpiodstubs.cpp
@@ -5,17 +5,19 @@
 
 const int piId = 0;
 
+static std::ostream* os = &std::cout;
+
 static bool libraryInitialised = false;
 
 int pigpio_start(char *addrStr, char *portStr) {
-  std::cout << __FUNCTION__;
+  (*os) << __FUNCTION__;
   if( addrStr ) {
-    std::cout << " " << addrStr;
+    (*os) << " " << addrStr;
   }
   if( portStr ) {
-    std::cout << " " << portStr;
+    (*os) << " " << portStr;
   }
-  std::cout << std::endl;
+  (*os) << std::endl;
 
   if( libraryInitialised ) {
     throw std::logic_error("Library already initialised");
@@ -27,7 +29,7 @@ int pigpio_start(char *addrStr, char *portStr) {
 }
 
 void pigpio_stop(int pi) {
-  std::cout << __FUNCTION__ << std::endl;
+  (*os) << __FUNCTION__ << std::endl;
   if( piId != pi ) {
     throw std::logic_error("Bad pi");
   }

--- a/src/pigpiod/pigpiodstubs.cpp
+++ b/src/pigpiod/pigpiodstubs.cpp
@@ -9,8 +9,12 @@ static bool libraryInitialised = false;
 
 int pigpio_start(char *addrStr, char *portStr) {
   std::cout << __FUNCTION__;
-  std::cout << ": " << addrStr;
-  std::cout << " " << portStr;
+  if( addrStr ) {
+    std::cout << " " << addrStr;
+  }
+  if( portStr ) {
+    std::cout << " " << portStr;
+  }
   std::cout << std::endl;
 
   if( libraryInitialised ) {

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -47,6 +47,8 @@ list(APPEND srcs configurationreadertests.cpp)
 
 list(APPEND srcs pwitemmanagertests.cpp)
 
+list(APPEND srcs librarymanagertests.cpp)
+
 add_executable(LinesideTest ${srcs})
 target_include_directories(LinesideTest
   SYSTEM PRIVATE ${Boost_INCLUDE_DIRS})

--- a/tst/librarymanagertests.cpp
+++ b/tst/librarymanagertests.cpp
@@ -23,4 +23,4 @@ BOOST_AUTO_TEST_CASE( NoDoubleInitialise )
 			 GetExceptionMessageChecker<std::logic_error>(msg) );
 }
 
-BOOST_AUTO_TEST_SUITE_END();
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/librarymanagertests.cpp
+++ b/tst/librarymanagertests.cpp
@@ -1,0 +1,26 @@
+#include <boost/test/unit_test.hpp>
+
+#include "exceptionmessagecheck.hpp"
+
+#include "pigpiod/librarymanager.hpp"
+
+BOOST_AUTO_TEST_SUITE( LibraryManager )
+
+BOOST_AUTO_TEST_CASE( Smoke )
+{
+  auto lm = Lineside::PiGPIOd::LibraryManager::CreateLibraryManager();
+  BOOST_CHECK_EQUAL( lm.use_count(), 1 );
+}
+
+BOOST_AUTO_TEST_CASE( NoDoubleInitialise )
+{
+  auto lm = Lineside::PiGPIOd::LibraryManager::CreateLibraryManager();
+  BOOST_CHECK_EQUAL( lm.use_count(), 1 );
+
+  std::string msg("CreateLibraryManager: Already initialised");
+  BOOST_CHECK_EXCEPTION( Lineside::PiGPIOd::LibraryManager::CreateLibraryManager(),
+			 std::logic_error,
+			 GetExceptionMessageChecker<std::logic_error>(msg) );
+}
+
+BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
This represents the initial integration of the [`pigpiod` library](http://abyz.me.uk/rpi/pigpio/pigpiod.html). There are two main components:
- A set of stubs (in `pigpiodstubs.hpp`) which log calls if `pigpiod` is not available
- A `LibraryManager` which handles initialisation of the `pigpiod` library (or the stub library)

The `pigpiod` library will be kept alive so long as the `LibraryManager` singleton exists. We use a `std::shared_ptr` for this, relying on the [reference count being thread-safe](https://en.cppreference.com/w/cpp/memory/shared_ptr). So long as we only copy the `std::shared_ptr` to the singleton, this should suffice.