### PR TITLE
CMake Tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ find_package(Doxygen)
 find_package(XercesC REQUIRED)
 
 find_package(pigpio)
-
 # --------
 
 # Configure the language standard
@@ -26,7 +25,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Handle pigpiod
 if( pigpio_FOUND )
-  add_compile_options("-DHAVE_PIGPIO")
+  add_compile_definitions("HAVE_PIGPIO")
 endif()
 
 # Warning options for the compiler

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -1,14 +1,5 @@
 set(srcs test.cpp)
 
-list(APPEND srcs mocks/mockbip.cpp)
-list(APPEND srcs mocks/mockpwmchannel.cpp)
-list(APPEND srcs mocks/mockpwmchannelprovider.cpp)
-list(APPEND srcs mocks/mockbopprovider.cpp)
-list(APPEND srcs mocks/mockbipprovider.cpp)
-list(APPEND srcs mocks/mockhardwaremanager.cpp)
-list(APPEND srcs mocks/mockrtcclient.cpp)
-list(APPEND srcs mocks/mocksoftwaremanager.cpp)
-
 list(APPEND srcs mockbiptests.cpp)
 list(APPEND srcs mockpwmchanneltests.cpp)
 list(APPEND srcs mockpwmchannelprovidertests.cpp)
@@ -58,5 +49,8 @@ target_include_directories(LinesideTest
 target_link_libraries(LinesideTest lineside ${Boost_LIBRARIES})
 
 add_test(NAME AllTests COMMAND LinesideTest)
+
+add_subdirectory(mocks)
+
 
 add_subdirectory(xmlsamples)

--- a/tst/mocks/CMakeLists.txt
+++ b/tst/mocks/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(srcs)
+
+list(APPEND srcs mockbip.cpp)
+list(APPEND srcs mockpwmchannel.cpp)
+list(APPEND srcs mockpwmchannelprovider.cpp)
+list(APPEND srcs mockbopprovider.cpp)
+list(APPEND srcs mockbipprovider.cpp)
+list(APPEND srcs mockhardwaremanager.cpp)
+list(APPEND srcs mockrtcclient.cpp)
+list(APPEND srcs mocksoftwaremanager.cpp)
+
+target_sources(LinesideTest PRIVATE ${srcs} )


### PR DESCRIPTION
Some minor CMake changes
- Use `add_compile_definitions`
- Add a separate `CMakeLists.txt` for the `tst/mocks` directory