### PR TITLE
Simple signal application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ add_link_options("${_profile_opts}")
 
 add_subdirectory( src )
 add_subdirectory( tst )
+add_subdirectory( apps )
 
 # --------
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(signals)

--- a/apps/signals/CMakeLists.txt
+++ b/apps/signals/CMakeLists.txt
@@ -1,11 +1,14 @@
 set(srcs)
 
 list(APPEND srcs main.cpp)
-
+list(APPEND srcs cmdlineopts.cpp)
 
 add_executable(Signals ${srcs})
+
+target_include_directories(Signals
+  SYSTEM PRIVATE ${Boost_INCLUDE_DIRS})
 
 # Note that linking against the lineside library will
 # automatically include the corresponding headers in
 # the compile commands
-target_link_libraries(Signals lineside)
+target_link_libraries(Signals lineside ${Boost_LIBRARIES})

--- a/apps/signals/CMakeLists.txt
+++ b/apps/signals/CMakeLists.txt
@@ -12,3 +12,5 @@ target_include_directories(Signals
 # automatically include the corresponding headers in
 # the compile commands
 target_link_libraries(Signals lineside ${Boost_LIBRARIES})
+
+configure_file(single-signal.xml . COPYONLY)

--- a/apps/signals/CMakeLists.txt
+++ b/apps/signals/CMakeLists.txt
@@ -2,6 +2,7 @@ set(srcs)
 
 list(APPEND srcs main.cpp)
 list(APPEND srcs cmdlineopts.cpp)
+list(APPEND srcs stubsoftwaremanager.cpp)
 
 add_executable(Signals ${srcs})
 

--- a/apps/signals/CMakeLists.txt
+++ b/apps/signals/CMakeLists.txt
@@ -3,6 +3,7 @@ set(srcs)
 list(APPEND srcs main.cpp)
 list(APPEND srcs cmdlineopts.cpp)
 list(APPEND srcs stubsoftwaremanager.cpp)
+list(APPEND srcs runonconsole.cpp)
 
 add_executable(Signals ${srcs})
 

--- a/apps/signals/CMakeLists.txt
+++ b/apps/signals/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(srcs)
+
+list(APPEND srcs main.cpp)
+
+
+add_executable(Signals ${srcs})
+
+# Note that linking against the lineside library will
+# automatically include the corresponding headers in
+# the compile commands
+target_link_libraries(Signals lineside)

--- a/apps/signals/cmdlineopts.cpp
+++ b/apps/signals/cmdlineopts.cpp
@@ -1,0 +1,38 @@
+#include <iostream>
+#include <boost/program_options.hpp>
+
+#include "cmdlineopts.hpp"
+
+namespace bpo = boost::program_options;
+
+void CmdLineOpts::Populate(int argc, char* argv[]) {
+  const std::string configOpt = "configuration-file";
+  const char configOptSingle = 'f';
+  const std::string configOptDesc = "Path to configuration XML file";
+
+  const std::string configOptSpec = configOpt + "," + configOptSingle;
+
+  bpo::options_description desc("Allowed Options");
+  desc.add_options()
+    ("help", "Show help message")
+    (configOptSpec.c_str(), bpo::value<std::string>(&(this->configFilePath)), configOptDesc.c_str())
+    ;
+  
+  bpo::variables_map vm;
+  bpo::store(bpo::parse_command_line(argc, argv, desc), vm);
+  bpo::notify(vm);
+  
+  if( vm.count("help") ) {
+    std::cout << desc << std::endl;
+    this->helpMessagePrinted = true;
+    return;
+  }
+
+  if( vm.count(configOpt.c_str()) ) {
+    std::cout << "Configuration file: " << this->configFilePath << std::endl;
+  } else {
+    throw std::runtime_error("Configuration file not specified");
+  }
+
+}
+

--- a/apps/signals/cmdlineopts.hpp
+++ b/apps/signals/cmdlineopts.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+class CmdLineOpts {
+public:
+  CmdLineOpts() :
+    helpMessagePrinted(false),
+    configFilePath() {}
+
+  bool helpMessagePrinted;
+  std::string configFilePath;
+
+  void Populate(int argc, char* argv[]);
+};

--- a/apps/signals/consoledriver.hpp
+++ b/apps/signals/consoledriver.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "pwitemmanager.hpp"

--- a/apps/signals/main.cpp
+++ b/apps/signals/main.cpp
@@ -1,7 +1,20 @@
 #include <cstdlib>
 #include <iostream>
 
+#include "xml/configurationreader.hpp"
+#include "multiaspectsignalheaddata.hpp"
+
 #include "cmdlineopts.hpp"
+
+
+void CheckPWItems(const std::vector<std::shared_ptr<Lineside::PWItemData>>& pwItems) {
+  for( auto it=pwItems.begin(); it!=pwItems.end(); ++it ) {
+    auto signal = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHeadData>(*it);
+    if( !signal ) {
+      throw std::runtime_error("All PWItems must be of type MultiAspectSignalHead");
+    }
+  }
+}
 
 int main(int argc, char* argv[]) {
   try {
@@ -10,6 +23,12 @@ int main(int argc, char* argv[]) {
     if( opts.helpMessagePrinted ) {
       return EXIT_SUCCESS;
     }
+
+    Lineside::xml::ConfigurationReader cr;
+
+    auto config = cr.Read(opts.configFilePath);
+    CheckPWItems(config.pwItems);
+
   }
   catch(std::exception& e) {
     std::cerr << "Error: " << e.what() << std::endl;

--- a/apps/signals/main.cpp
+++ b/apps/signals/main.cpp
@@ -9,6 +9,7 @@
 
 #include "cmdlineopts.hpp"
 #include "stubsoftwaremanager.hpp"
+#include "runonconsole.hpp"
 
 void CheckPWItems(const std::vector<std::shared_ptr<Lineside::PWItemData>>& pwItems) {
   for( auto it=pwItems.begin(); it!=pwItems.end(); ++it ) {
@@ -38,6 +39,7 @@ int main(int argc, char* argv[]) {
 
     pwItemManager.CreatePWItems(config.pwItems);
     
+    RunOnConsole(pwItemManager);
   }
   catch(std::exception& e) {
     std::cerr << "Error: " << e.what() << std::endl;

--- a/apps/signals/main.cpp
+++ b/apps/signals/main.cpp
@@ -1,0 +1,6 @@
+#include <cstdlib>
+#include <iostream>
+
+int main() {
+  return EXIT_SUCCESS;
+}

--- a/apps/signals/main.cpp
+++ b/apps/signals/main.cpp
@@ -1,11 +1,14 @@
 #include <cstdlib>
 #include <iostream>
 
+#include "pigpiod/pihardwaremanager.hpp"
 #include "xml/configurationreader.hpp"
 #include "multiaspectsignalheaddata.hpp"
 
-#include "cmdlineopts.hpp"
+#include "pwitemmanager.hpp"
 
+#include "cmdlineopts.hpp"
+#include "stubsoftwaremanager.hpp"
 
 void CheckPWItems(const std::vector<std::shared_ptr<Lineside::PWItemData>>& pwItems) {
   for( auto it=pwItems.begin(); it!=pwItems.end(); ++it ) {
@@ -29,6 +32,12 @@ int main(int argc, char* argv[]) {
     auto config = cr.Read(opts.configFilePath);
     CheckPWItems(config.pwItems);
 
+    auto hw = std::make_shared<Lineside::PiGPIOd::PiHardwareManager>(config.hwManager);
+    auto sw = std::make_shared<StubSoftwareManager>();
+    Lineside::PWItemManager pwItemManager( hw, sw );
+
+    pwItemManager.CreatePWItems(config.pwItems);
+    
   }
   catch(std::exception& e) {
     std::cerr << "Error: " << e.what() << std::endl;

--- a/apps/signals/main.cpp
+++ b/apps/signals/main.cpp
@@ -1,6 +1,20 @@
 #include <cstdlib>
 #include <iostream>
 
-int main() {
+#include "cmdlineopts.hpp"
+
+int main(int argc, char* argv[]) {
+  try {
+    CmdLineOpts opts;
+    opts.Populate(argc, argv);
+    if( opts.helpMessagePrinted ) {
+      return EXIT_SUCCESS;
+    }
+  }
+  catch(std::exception& e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  
   return EXIT_SUCCESS;
 }

--- a/apps/signals/runonconsole.cpp
+++ b/apps/signals/runonconsole.cpp
@@ -1,0 +1,85 @@
+#include <string>
+#include <vector>
+
+#include "signalstate.hpp"
+#include "signalflash.hpp"
+#include "multiaspectsignalhead.hpp"
+#include "utility.hpp"
+
+#include "runonconsole.hpp"
+
+std::vector<std::string>  stringtotokens( const std::string s) {
+  std::vector<std::string> tokens;
+  std::stringstream nxt;
+  
+  for( auto c=s.begin(); c!=s.end(); ++c ) {
+    if( std::isspace(*c) ) {
+      if( nxt.tellp() != 0 ) {
+	// Just completed a token
+	tokens.push_back(nxt.str());
+	nxt.str(std::string());
+      }
+    } else {
+      nxt << (*c);
+    }
+  }
+  // Need to catch case where token ends line
+  if( nxt.tellp() != 0 ) {
+    // Just completed a token
+    tokens.push_back(nxt.str());
+  }
+  
+  return tokens;
+}
+
+void HandleMASH( Lineside::MultiAspectSignalHead& mash,
+		 std::vector<std::string>& tokens ) {
+  if( tokens.size() != 4 ) {
+    std::cerr << __FUNCTION__ << ": Needs four tokens" << std::endl;
+    return;
+  }
+  
+  auto state = Lineside::Parse<Lineside::SignalState>(tokens.at(1));
+  auto flash = Lineside::Parse<Lineside::SignalFlash>(tokens.at(2));
+  auto feather = std::stoul(tokens.at(3));
+
+  mash.SetState(state, flash, feather);
+}
+
+void RunOnConsole(Lineside::PWItemManager& pwItemManager) {
+  std::cout << "Entering main loop" << std::endl;
+
+  bool done = false;
+
+  while( !done ) {
+    std::string inputLine;
+      
+    std::getline( std::cin, inputLine );
+    if( inputLine == "q" ) {
+      std::cout << "Received quit" << std::endl;
+      done = true;
+    } else {
+      auto tokens = stringtotokens(inputLine);
+
+      Lineside::ItemId target;
+
+      try {
+	target.Parse(tokens.at(0));
+
+	auto pwItem = pwItemManager.GetPWItemModelById(target);
+	LOCK_OR_THROW( pwItemShared, pwItem );
+	auto mash = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>( pwItemShared );
+	if( !mash ) {
+	  throw std::logic_error("Not a MultiAspectSignalHead");
+	}
+	HandleMASH( *mash, tokens );
+      }
+      catch( std::exception& e ) {
+	std::cerr << e.what() << std::endl;
+	continue;
+      }
+      
+    }
+  }
+}
+

--- a/apps/signals/runonconsole.hpp
+++ b/apps/signals/runonconsole.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "pwitemmanager.hpp"
+
+void RunOnConsole(Lineside::PWItemManager& pwItemManager);

--- a/apps/signals/single-signal.xml
+++ b/apps/signals/single-signal.xml
@@ -16,13 +16,13 @@
 	<BinaryOutput controller="GPIO" controllerData="03" />
       </Aspect>
       <Aspect name="Yellow1">
-	<BinaryOutput controller="GPIO1" controllerData="04" />
+	<BinaryOutput controller="GPIO" controllerData="04" />
       </Aspect>
       <Aspect name="Green">
-	<BinaryOutput controller="GPIO3" controllerData="06" />
+	<BinaryOutput controller="GPIO" controllerData="06" />
       </Aspect>
       <Feather route="1">
-	<BinaryOutput controller="GPIO2" controllerData="08" />
+	<BinaryOutput controller="GPIO" controllerData="08" />
       </Feather>
     </MultiAspectSignalHead>
   </PermanentWayItems>

--- a/apps/signals/single-signal.xml
+++ b/apps/signals/single-signal.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<LinesideCabinet>
+  <SoftwareManager>
+    <RTC address="addr" port="8081" />
+    <Settings>
+      <Setting key="aKey" value="bValue" />
+    </Settings>
+  </SoftwareManager>
+  <HardwareManager>
+    <I2CDevices />
+    <Settings />
+  </HardwareManager>
+  <PermanentWayItems>
+    <MultiAspectSignalHead id="00:1a:2b:3c">
+      <Aspect name="Red">
+	<BinaryOutput controller="GPIO" controllerData="03" />
+      </Aspect>
+      <Aspect name="Yellow1">
+	<BinaryOutput controller="GPIO1" controllerData="04" />
+      </Aspect>
+      <Aspect name="Green">
+	<BinaryOutput controller="GPIO3" controllerData="06" />
+      </Aspect>
+      <Feather route="1">
+	<BinaryOutput controller="GPIO2" controllerData="08" />
+      </Feather>
+    </MultiAspectSignalHead>
+  </PermanentWayItems>
+</LinesideCabinet>

--- a/apps/signals/single-signal.xml
+++ b/apps/signals/single-signal.xml
@@ -13,16 +13,16 @@
   <PermanentWayItems>
     <MultiAspectSignalHead id="00:1a:2b:3c">
       <Aspect name="Red">
-	<BinaryOutput controller="GPIO" controllerData="03" />
+	<BinaryOutput controller="GPIO" controllerData="19" />
       </Aspect>
       <Aspect name="Yellow1">
-	<BinaryOutput controller="GPIO" controllerData="04" />
+	<BinaryOutput controller="GPIO" controllerData="13" />
       </Aspect>
       <Aspect name="Green">
 	<BinaryOutput controller="GPIO" controllerData="06" />
       </Aspect>
       <Feather route="1">
-	<BinaryOutput controller="GPIO" controllerData="08" />
+	<BinaryOutput controller="GPIO" controllerData="05" />
       </Feather>
     </MultiAspectSignalHead>
   </PermanentWayItems>

--- a/apps/signals/single-signal.xml
+++ b/apps/signals/single-signal.xml
@@ -16,7 +16,7 @@
 	<BinaryOutput controller="GPIO" controllerData="19" />
       </Aspect>
       <Aspect name="Yellow1">
-	<BinaryOutput controller="GPIO" controllerData="13" />
+	<BinaryOutput controller="GPIO" controllerData="26" />
       </Aspect>
       <Aspect name="Green">
 	<BinaryOutput controller="GPIO" controllerData="06" />

--- a/apps/signals/stubsoftwaremanager.cpp
+++ b/apps/signals/stubsoftwaremanager.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+
+#include "stubsoftwaremanager.hpp"
+
+void StubRTCClient::SendTrackCircuitNotification(const Lineside::ItemId trackCircuitId,
+						 const bool occupied ) {
+  std::cout << __FUNCTION__ << ": "
+	    << trackCircuitId << " "
+	    << occupied << std::endl;
+}
+
+std::weak_ptr<Lineside::RTCClient> StubSoftwareManager::GetRTCClient() {
+  auto result = std::make_shared<StubRTCClient>();
+
+  this->rtcClientList.push_back(result);
+
+  return result;
+}

--- a/apps/signals/stubsoftwaremanager.hpp
+++ b/apps/signals/stubsoftwaremanager.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "rtcclient.hpp"
+#include "softwaremanager.hpp"
+
+class StubRTCClient : public Lineside::RTCClient {
+public:
+  StubRTCClient() : RTCClient() {}
+  
+  virtual void SendTrackCircuitNotification(const Lineside::ItemId trackCircuitId,
+					    const bool occupied ) override;
+};
+
+class StubSoftwareManager : public Lineside::SoftwareManager {
+public:
+  StubSoftwareManager() :
+    SoftwareManager(),
+    rtcClientList() {}
+  
+  virtual std::weak_ptr<Lineside::RTCClient> GetRTCClient() override;
+  
+  std::vector<std::shared_ptr<StubRTCClient>> rtcClientList;
+};

--- a/include/multiaspectsignalheaddata.hpp
+++ b/include/multiaspectsignalheaddata.hpp
@@ -21,17 +21,17 @@ namespace Lineside {
     //! Perform some basic sanity checks
     void CheckData() const;
     
-    virtual std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw,
-						    std::shared_ptr<SoftwareManager> sw ) const override;
+    virtual std::shared_ptr<PWItemModel> Construct(HardwareManager& hw,
+						   SoftwareManager& sw ) const override;
 
   private:
-    std::shared_ptr<BinaryOutputPin> FetchBOP( std::shared_ptr<HardwareManager> hw,
-					       const DeviceRequestData& drd ) const;
+    std::shared_ptr<BinaryOutputPin> FetchBOP(HardwareManager& hw,
+					      const DeviceRequestData& drd ) const;
     
-    void PopulateAspects( std::shared_ptr<HardwareManager> hw,
-			  std::shared_ptr<MultiAspectSignalHead> target ) const;
+    void PopulateAspects(HardwareManager& hw,
+			 std::shared_ptr<MultiAspectSignalHead> target ) const;
 
-    void PopulateFeathers( std::shared_ptr<HardwareManager> hw,
-			   std::shared_ptr<MultiAspectSignalHead> target) const;
+    void PopulateFeathers(HardwareManager& hw,
+			  std::shared_ptr<MultiAspectSignalHead> target) const;
   };
 }

--- a/include/pwitemdata.hpp
+++ b/include/pwitemdata.hpp
@@ -17,7 +17,16 @@ namespace Lineside {
 
     virtual ~PWItemData() {}
 
-    virtual std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw,
-						    std::shared_ptr<SoftwareManager> sw ) const = 0;
+    virtual
+    std::shared_ptr<PWItemModel> Construct(HardwareManager& hw,
+					   SoftwareManager& sw) const = 0;
+
+  protected:
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+    void UnusedSoftwareManager(const SoftwareManager& sw) const {
+      // Do nothing
+    }
+#pragma clang diagnostic pop
   };
 }

--- a/include/pwitemdata.hpp
+++ b/include/pwitemdata.hpp
@@ -17,16 +17,13 @@ namespace Lineside {
 
     virtual ~PWItemData() {}
 
+    //! Method to construct a permanent way item
     virtual
     std::shared_ptr<PWItemModel> Construct(HardwareManager& hw,
 					   SoftwareManager& sw) const = 0;
 
   protected:
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-    void UnusedSoftwareManager(const SoftwareManager& sw) const {
-      // Do nothing
-    }
-#pragma clang diagnostic pop
+    //! Method for suppressing compiler warnings about unused SoftwareManager parameters
+    void UnusedSoftwareManager(const SoftwareManager& sw) const;
   };
 }

--- a/include/servoturnoutmotordata.hpp
+++ b/include/servoturnoutmotordata.hpp
@@ -12,7 +12,7 @@ namespace Lineside {
     unsigned int curved;
     DeviceRequestData pwmChannelRequest;
 
-    virtual std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw,
-						    std::shared_ptr<SoftwareManager> sw ) const override;
+    virtual std::shared_ptr<PWItemModel> Construct(HardwareManager& hw,
+						   SoftwareManager& sw) const override;
   };
 }

--- a/include/signalflash.hpp
+++ b/include/signalflash.hpp
@@ -3,10 +3,16 @@
 #include <iostream>
 #include <string>
 
+#include "parse.hpp"
+
 namespace Lineside {
   enum class SignalFlash { Steady, Flashing };
 
   std::ostream& operator<<( std::ostream& os, const SignalFlash s );
   
   std::string ToString( const SignalFlash s );
+
+  //! Template specialisation to parse a string to a SignalFlash
+  template<>
+  SignalFlash Parse<SignalFlash>(const std::string& src);
 }

--- a/include/signalstate.hpp
+++ b/include/signalstate.hpp
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <string>
 
+#include "parse.hpp"
+
 namespace Lineside {
   enum class SignalState { Red,
 			   DoubleYellow,
@@ -13,4 +15,8 @@ namespace Lineside {
   std::ostream& operator<<( std::ostream& os, const SignalState s );
   
   std::string ToString( const SignalState s );
+
+  //! Template specialisation to parse a string to a SignalState
+  template<>
+  SignalState Parse<SignalState>(const std::string& src );
 }

--- a/include/trackcircuitmonitordata.hpp
+++ b/include/trackcircuitmonitordata.hpp
@@ -13,7 +13,7 @@ namespace Lineside {
 
     DeviceRequestData inputPinRequest;
 
-    virtual std::shared_ptr<PWItemModel> Construct( std::shared_ptr<HardwareManager> hw,
-						    std::shared_ptr<SoftwareManager> sw ) const override;
+    virtual std::shared_ptr<PWItemModel> Construct(HardwareManager& hw,
+						   SoftwareManager& sw ) const override;
   };
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,8 @@ list(APPEND srcs binaryinputpin.cpp)
 list(APPEND srcs pwitemmodel.cpp)
 list(APPEND srcs pwitemcontroller.cpp)
 
+list(APPEND srcs pwitemdata.cpp)
+
 list(APPEND srcs servoturnoutmotordata.cpp)
 list(APPEND srcs servoturnoutmotor.cpp)
 

--- a/src/multiaspectsignalhead.cpp
+++ b/src/multiaspectsignalhead.cpp
@@ -15,15 +15,17 @@ namespace Lineside {
   std::chrono::milliseconds MultiAspectSignalHead::OnRun() {
     std::lock_guard<std::mutex> lockState(this->stateChangeMtx);
 
-    this->turnAllOff();
-
-    this->setStateFromDesired();
-
-    this->setFeatherFromDesired();
-
-    this->currentState = this->desiredState;
-    this->currentFlash = this->desiredFlash;
-    this->currentFeather = this->desiredFeather;
+    if( this->HaveStateChange() || (this->currentFlash == SignalFlash::Flashing)) {
+	this->turnAllOff();
+	
+	this->setStateFromDesired();
+	
+	this->setFeatherFromDesired();
+	
+	this->currentState = this->desiredState;
+	this->currentFlash = this->desiredFlash;
+	this->currentFeather = this->desiredFeather;
+      }
     return MultiAspectSignalHead::FlashInterval;
   }
 

--- a/src/multiaspectsignalhead.cpp
+++ b/src/multiaspectsignalhead.cpp
@@ -41,7 +41,7 @@ namespace Lineside {
 				       const SignalFlash wantedFlash,
 				       const unsigned int wantedFeather ) {
     std::lock_guard<std::mutex> lockState(this->stateChangeMtx);
-
+    
     // Checks on the aspects
     if( wantedState == SignalState::Yellow ) {
       if( !this->yellow1 ) {

--- a/src/multiaspectsignalheaddata.cpp
+++ b/src/multiaspectsignalheaddata.cpp
@@ -45,15 +45,11 @@ namespace Lineside {
   }
 
   std::shared_ptr<PWItemModel>
-  MultiAspectSignalHeadData::Construct( std::shared_ptr<HardwareManager> hw,
-					std::shared_ptr<SoftwareManager> sw ) const {
-    if( !hw ) {
-      throw std::logic_error("Bad hw ptr");
-    }
-    if( !sw ) {
-      throw std::logic_error("Bad sw ptr");
-    }
-
+  MultiAspectSignalHeadData::Construct(HardwareManager& hw,
+				       SoftwareManager& sw ) const {
+    // Work around unused parameter warning
+    this->UnusedSoftwareManager(sw);
+    
     this->CheckData();
 
     // Work around private constructor of the MultiAspectSignalHead
@@ -71,15 +67,15 @@ namespace Lineside {
   }
 
   std::shared_ptr<BinaryOutputPin>
-  MultiAspectSignalHeadData::FetchBOP( std::shared_ptr<HardwareManager> hw,
-				       const DeviceRequestData& drd ) const {
-    auto bopProvider = hw->bopProviderRegistrar.Retrieve(drd.controller);
+  MultiAspectSignalHeadData::FetchBOP(HardwareManager& hw,
+				      const DeviceRequestData& drd ) const {
+    auto bopProvider = hw.bopProviderRegistrar.Retrieve(drd.controller);
     return bopProvider->GetHardware( drd.controllerData, drd.settings );
   }
   
   void
-  MultiAspectSignalHeadData::PopulateAspects( std::shared_ptr<HardwareManager> hw,
-					      std::shared_ptr<MultiAspectSignalHead> target ) const {
+  MultiAspectSignalHeadData::PopulateAspects(HardwareManager& hw,
+					     std::shared_ptr<MultiAspectSignalHead> target ) const {
     // Calling from private method, so can assume CheckData() has been called
     
     // Must have red and green aspects
@@ -96,8 +92,8 @@ namespace Lineside {
   }
 
   void
-  MultiAspectSignalHeadData::PopulateFeathers( std::shared_ptr<HardwareManager> hw,
-					       std::shared_ptr<MultiAspectSignalHead> target ) const {
+  MultiAspectSignalHeadData::PopulateFeathers(HardwareManager& hw,
+					      std::shared_ptr<MultiAspectSignalHead> target ) const {
     // Calling from private method, so assume CheckData() has been called
     
     // The map is nicely sorted by the keys (which are unsigned ints)

--- a/src/pwitemdata.cpp
+++ b/src/pwitemdata.cpp
@@ -1,0 +1,22 @@
+#include <boost/predef.h>
+
+#include "pwitemdata.hpp"
+
+namespace Lineside {
+#if defined(BOOST_COMP_GNUC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#elif defined(BOOST_COMP_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+  void PWItemData::UnusedSoftwareManager(const SoftwareManager& sw) const {
+    // Do nothing
+  }
+#if defined(BOOST_COMP_GNUC)
+#pragma GCC diagnostic pop
+#elif defined(BOOST_COMP_CLANG)
+#pragma clang diagnostic pop
+#endif
+  
+}

--- a/src/pwitemmanager.cpp
+++ b/src/pwitemmanager.cpp
@@ -16,7 +16,7 @@ namespace Lineside {
       if( this->pwItems.count( currId ) != 0 ) {
 	throw DuplicateKeyException(currId.ToString());
       }
-      auto pwItemModel = (*it)->Construct( this->hwManager, this->swManager );
+      auto pwItemModel = (*it)->Construct( *(this->hwManager), *(this->swManager) );
 
       auto pwItemController = PWItemController::Construct( pwItemModel );
 

--- a/src/servoturnoutmotordata.cpp
+++ b/src/servoturnoutmotordata.cpp
@@ -10,16 +10,12 @@ namespace Lineside {
     curved(),
     pwmChannelRequest() {}
 
-  std::shared_ptr<PWItemModel> ServoTurnoutMotorData::Construct( std::shared_ptr<HardwareManager> hw,
-								 std::shared_ptr<SoftwareManager> sw ) const {
-    if( !hw ) {
-      throw std::logic_error("Bad hw ptr");
-    }
-    if( !sw ) {
-      throw std::logic_error("Bad sw ptr");
-    }
-
-    auto pwmChannelProvider = hw->pwmcProviderRegistrar.Retrieve(this->pwmChannelRequest.controller);
+  std::shared_ptr<PWItemModel> ServoTurnoutMotorData::Construct( HardwareManager& hw,
+								 SoftwareManager& sw ) const {
+    // Work around compiler warning/error
+    this->UnusedSoftwareManager(sw);
+    
+    auto pwmChannelProvider = hw.pwmcProviderRegistrar.Retrieve(this->pwmChannelRequest.controller);
     std::shared_ptr<PWMChannel> servo;
     servo = pwmChannelProvider->GetHardware(this->pwmChannelRequest.controllerData,
 					    this->pwmChannelRequest.settings);

--- a/src/signalflash.cpp
+++ b/src/signalflash.cpp
@@ -36,4 +36,24 @@ namespace Lineside {
 
     return res;
   }
+  
+  template<>
+  SignalFlash Parse<SignalFlash>(const std::string& src) {
+    if( convertor.empty() ) {
+      initconvertor();
+    }
+
+    try {
+      SignalFlash sf;
+      sf = convertor.right.at(src);
+      return sf;
+    }
+    catch( std::out_of_range& e ) {
+      std::stringstream msg;
+      msg << "Could not parse '";
+      msg << src;
+      msg << "' to SignalState";
+      throw std::invalid_argument(msg.str());
+    }
+  }
 }

--- a/src/signalstate.cpp
+++ b/src/signalstate.cpp
@@ -38,4 +38,24 @@ namespace Lineside {
 
     return res;
   }
+
+  template<>
+  SignalState Parse<SignalState>(const std::string& src) {
+    if( convertor.empty() ) {
+      initconvertor();
+    }
+
+    try {
+      SignalState sigState;
+      sigState = convertor.right.at(src);
+      return sigState;
+    }
+    catch( std::out_of_range& e ) {
+      std::stringstream msg;
+      msg << "Could not parse '";
+      msg << src;
+      msg << "' to SignalState";
+      throw std::invalid_argument(msg.str());
+    }
+  }
 }

--- a/src/trackcircuitmonitordata.cpp
+++ b/src/trackcircuitmonitordata.cpp
@@ -5,16 +5,9 @@
 
 namespace Lineside {
   std::shared_ptr<PWItemModel>
-  TrackCircuitMonitorData::Construct( std::shared_ptr<HardwareManager> hw,
-				      std::shared_ptr<SoftwareManager> sw ) const {
-    if( !hw ) {
-      throw std::logic_error("Bad hw ptr");
-    }
-    if( !sw ) {
-      throw std::logic_error("Bad sw ptr");
-    }
-
-    auto bipProvider = hw->bipProviderRegistrar.Retrieve(this->inputPinRequest.controller);
+  TrackCircuitMonitorData::Construct(HardwareManager& hw,
+				     SoftwareManager& sw) const {
+    auto bipProvider = hw.bipProviderRegistrar.Retrieve(this->inputPinRequest.controller);
     auto bip = bipProvider->GetHardware( this->inputPinRequest.controllerData,
 					 this->inputPinRequest.settings );
 
@@ -31,7 +24,7 @@ namespace Lineside {
     result->monitorPin = bip;
 
     // Get RTC client
-    result->rtc = sw->GetRTCClient();
+    result->rtc = sw.GetRTCClient();
 
     return result;
   }

--- a/tst/multiaspectsignalheadtests.cpp
+++ b/tst/multiaspectsignalheadtests.cpp
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(ConstructTwoAspect)
 
   auto mashd = MakeTwoAspect( id, this->hwManager->BOPProviderId ); 
 
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(ConstructThreeAspect)
 
   auto mashd = MakeThreeAspect( id, this->hwManager->BOPProviderId );
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(ConstructFourAspect)
   
   auto mashd = MakeFourAspect( id, this->hwManager->BOPProviderId );
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(ConstructTwoAspectWithOneFeather)
 
   auto mashd = MakeTwoAspectOneFeather( id, this->hwManager->BOPProviderId ); 
 
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(ConstructTwoAspectWithTwoFeathers)
 
   auto mashd = MakeTwoAspectTwoFeather( id, this->hwManager->BOPProviderId ); 
 
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(TwoAspectSetState)
   
   auto mashd = MakeTwoAspect( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE(ThreeAspectSetState)
   
   auto mashd = MakeThreeAspect( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -269,7 +269,7 @@ BOOST_AUTO_TEST_CASE(FourAspectSetState)
   
   auto mashd = MakeFourAspect( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -299,7 +299,7 @@ BOOST_AUTO_TEST_CASE(TwoAspectSetStateWithTwoFeathers)
   
   auto mashd = MakeTwoAspectTwoFeather( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(TwoAspectSetStateThrowsOnBadAspect)
   
   auto mashd = MakeTwoAspect( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE(ThreeAspectSetStateThrowsOnBadAspect)
   
   auto mashd = MakeThreeAspect( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -399,7 +399,7 @@ BOOST_AUTO_TEST_CASE(TwoAspectSetStateThrowsOnBadFeather)
   
   auto mashd = MakeTwoAspect( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -433,7 +433,7 @@ BOOST_AUTO_TEST_CASE(TwoAspectOneFeatherSetStateThrowsOnBadFeather)
   
   auto mashd = MakeTwoAspectOneFeather( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -468,7 +468,7 @@ BOOST_AUTO_TEST_CASE(ShowsRedOnActivateTwoAspect)
   
   auto mashd = MakeTwoAspect( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -491,7 +491,7 @@ BOOST_AUTO_TEST_CASE(ShowsRedOnActivateFourAspect)
   
   auto mashd = MakeFourAspect( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -518,7 +518,7 @@ BOOST_AUTO_TEST_CASE(ShowsRedOnActivateTwoAspectWithFeather)
   
   auto mashd = MakeTwoAspectOneFeather( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -543,7 +543,7 @@ BOOST_AUTO_TEST_CASE(OnRunTwoAspectSteady)
   
   auto mashd = MakeTwoAspect( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -585,7 +585,7 @@ BOOST_AUTO_TEST_CASE(OnRunThreeAspectSteady)
   
   auto mashd = MakeThreeAspect( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -633,7 +633,7 @@ BOOST_AUTO_TEST_CASE(OnRunFourAspectSteady)
   
   auto mashd = MakeFourAspect( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -696,7 +696,7 @@ BOOST_AUTO_TEST_CASE( OnRunTwoAspectFlashing )
   
   auto mashd = MakeTwoAspect( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -738,7 +738,7 @@ BOOST_AUTO_TEST_CASE( OnRunTwoAspectTwoFeather )
   
   auto mashd = MakeTwoAspectTwoFeather( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -790,7 +790,7 @@ BOOST_AUTO_TEST_CASE(OnRunFeatherDoesNotFlash)
   
   auto mashd = MakeTwoAspectTwoFeather( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);
@@ -837,7 +837,7 @@ BOOST_AUTO_TEST_CASE( OnDeactivateTurnsAllOff )
   
   auto mashd = MakeTwoAspectTwoFeather( id, this->hwManager->BOPProviderId ); 
   
-  auto res = mashd.Construct( this->hwManager, this->swManager );
+  auto res = mashd.Construct( *(this->hwManager), *(this->swManager) );
   BOOST_REQUIRE( res );
   BOOST_CHECK_EQUAL( res->getId(), id );
   auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>(res);

--- a/tst/servoturnoutmotortests.cpp
+++ b/tst/servoturnoutmotortests.cpp
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE(Construct)
   stmd.pwmChannelRequest.controller = this->hwManager->PWMChannelProviderId;
   stmd.pwmChannelRequest.controllerData = controllerData;
 
-  auto pwItem = stmd.Construct(this->hwManager, this->swManager);
+  auto pwItem = stmd.Construct(*(this->hwManager), *(this->swManager));
   BOOST_REQUIRE( pwItem );
   BOOST_CHECK_EQUAL( pwItem->getId(), id );
   auto stm = std::dynamic_pointer_cast<Lineside::ServoTurnoutMotor>(pwItem);
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(OnActivateSetsStraight)
   stmd.pwmChannelRequest.controller = this->hwManager->PWMChannelProviderId;
   stmd.pwmChannelRequest.controllerData = controllerData;
 
-  auto pwItem = stmd.Construct(this->hwManager, this->swManager);
+  auto pwItem = stmd.Construct(*(this->hwManager), *(this->swManager));
   BOOST_REQUIRE( pwItem );
   BOOST_CHECK_EQUAL( pwItem->getId(), id );
   auto stm = std::dynamic_pointer_cast<Lineside::ServoTurnoutMotor>(pwItem);
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(SetStateAndStateChange)
   stmd.pwmChannelRequest.controller = this->hwManager->PWMChannelProviderId;
   stmd.pwmChannelRequest.controllerData = controllerData;
 
-  auto pwItem = stmd.Construct(this->hwManager, this->swManager);
+  auto pwItem = stmd.Construct(*(this->hwManager), *(this->swManager));
   pwItem->RegisterController(notifySrcId, nt);
   BOOST_REQUIRE( pwItem );
   BOOST_CHECK_EQUAL( pwItem->getId(), id );
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(SetCurvedAndStraight)
   stmd.pwmChannelRequest.controller = this->hwManager->PWMChannelProviderId;
   stmd.pwmChannelRequest.controllerData = controllerData;
 
-  auto pwItem = stmd.Construct(this->hwManager, this->swManager);
+  auto pwItem = stmd.Construct(*(this->hwManager), *(this->swManager));
   pwItem->RegisterController(notifySrcId, nt);
   BOOST_REQUIRE( pwItem );
   BOOST_CHECK_EQUAL( pwItem->getId(), id );

--- a/tst/signalflashtests.cpp
+++ b/tst/signalflashtests.cpp
@@ -27,5 +27,9 @@ BOOST_DATA_TEST_CASE( StreamInsertion, nameToFlashZip, name, flash )
   BOOST_CHECK_EQUAL( res.str(), name );
 }
 
+BOOST_DATA_TEST_CASE( Parse, nameToFlashZip, name, flash )
+{
+  BOOST_CHECK_EQUAL( flash, Lineside::Parse<Lineside::SignalFlash>(name) );
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/signalstatetests.cpp
+++ b/tst/signalstatetests.cpp
@@ -30,5 +30,9 @@ BOOST_DATA_TEST_CASE( StreamInsertion, nameToStateZip, name, state )
   BOOST_CHECK_EQUAL( res.str(), name );
 }
 
+BOOST_DATA_TEST_CASE( Parse, nameToStateZip, name, state )
+{
+  BOOST_CHECK_EQUAL( state, Lineside::Parse<Lineside::SignalState>(name) );
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/trackcircuitmonitortests.cpp
+++ b/tst/trackcircuitmonitortests.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(Construct)
   tcmd.inputPinRequest.controller = controller;
   tcmd.inputPinRequest.controllerData = controllerData;
 
-  auto pwItem = tcmd.Construct(this->hwManager, this->swManager);
+  auto pwItem = tcmd.Construct(*(this->hwManager), *(this->swManager));
   BOOST_REQUIRE( pwItem );
   BOOST_CHECK_EQUAL( pwItem->getId(), id );
   auto tcm = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitor>(pwItem);
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(SetOccupiedUnOccupied)
   tcmd.inputPinRequest.controller = controller;
   tcmd.inputPinRequest.controllerData = controllerData;
 
-  auto pwItem = tcmd.Construct(this->hwManager, this->swManager);
+  auto pwItem = tcmd.Construct(*(this->hwManager), *(this->swManager));
   BOOST_REQUIRE( pwItem );
   BOOST_CHECK_EQUAL( pwItem->getId(), id );
   auto tcm = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitor>(pwItem);
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(OnRunSendsToRTC)
   tcmd.inputPinRequest.controller = controller;
   tcmd.inputPinRequest.controllerData = controllerData;
 
-  auto pwItem = tcmd.Construct(this->hwManager, this->swManager);
+  auto pwItem = tcmd.Construct(*(this->hwManager), *(this->swManager));
   BOOST_REQUIRE( pwItem );
   BOOST_CHECK_EQUAL( pwItem->getId(), id );
   auto tcm = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitor>(pwItem);


### PR DESCRIPTION
Add a simple application for testing signals, which uses console input. Changes introduced along the way:
- Parsers for `SignalState` and `SignalFlash` and associated tests
- Change `PWItemData::Construct()` to take references instead of `std::shared_ptr<T>`
- Tweak `MultiAspectSignalHead::OnRun()` so that it doesn't do reset all LEDs on every call

The latter caused a small ripple of changes. The application will doubtless require more refactoring, but this has been tested with Pi hardware and actual LEDs