### PR TITLE
Have shared_ptr for RTCClient

### DIFF
--- a/apps/signals/stubsoftwaremanager.cpp
+++ b/apps/signals/stubsoftwaremanager.cpp
@@ -9,7 +9,7 @@ void StubRTCClient::SendTrackCircuitNotification(const Lineside::ItemId trackCir
 	    << occupied << std::endl;
 }
 
-std::weak_ptr<Lineside::RTCClient> StubSoftwareManager::GetRTCClient() {
+std::shared_ptr<Lineside::RTCClient> StubSoftwareManager::GetRTCClient() {
   auto result = std::make_shared<StubRTCClient>();
 
   this->rtcClientList.push_back(result);

--- a/apps/signals/stubsoftwaremanager.hpp
+++ b/apps/signals/stubsoftwaremanager.hpp
@@ -17,7 +17,7 @@ public:
     SoftwareManager(),
     rtcClientList() {}
   
-  virtual std::weak_ptr<Lineside::RTCClient> GetRTCClient() override;
+  virtual std::shared_ptr<Lineside::RTCClient> GetRTCClient() override;
   
   std::vector<std::shared_ptr<StubRTCClient>> rtcClientList;
 };

--- a/include/softwaremanager.hpp
+++ b/include/softwaremanager.hpp
@@ -10,6 +10,6 @@ namespace Lineside {
   public:
     virtual ~SoftwareManager() {}
     
-    virtual std::weak_ptr<RTCClient> GetRTCClient() = 0;
+    virtual std::shared_ptr<RTCClient> GetRTCClient() = 0;
   };
 }

--- a/include/trackcircuitmonitor.hpp
+++ b/include/trackcircuitmonitor.hpp
@@ -43,6 +43,6 @@ namespace Lineside {
     std::mutex updateMtx;
     std::atomic<bool> lastNotificationState;
     std::shared_ptr<BinaryInputPin> monitorPin;
-    std::weak_ptr<RTCClient> rtc;
+    std::shared_ptr<RTCClient> rtc;
   };
 }

--- a/src/trackcircuitmonitor.cpp
+++ b/src/trackcircuitmonitor.cpp
@@ -13,8 +13,7 @@ namespace Lineside {
     std::lock_guard<std::mutex> lockState(this->updateMtx);
     const bool notifyState = this->GetState();
 
-    LOCK_OR_THROW( rtcClient, this->rtc );
-    rtcClient->SendTrackCircuitNotification( this->getId(), notifyState );
+    this->rtc->SendTrackCircuitNotification(this->getId(), notifyState);
     this->lastNotificationState = notifyState;
     
     return TrackCircuitMonitor::SleepRequest;

--- a/tst/mocks/mocksoftwaremanager.cpp
+++ b/tst/mocks/mocksoftwaremanager.cpp
@@ -1,6 +1,6 @@
 #include "mocksoftwaremanager.hpp"
 
-std::weak_ptr<Lineside::RTCClient> MockSoftwareManager::GetRTCClient() {
+std::shared_ptr<Lineside::RTCClient> MockSoftwareManager::GetRTCClient() {
   auto nxt = std::make_shared<MockRTCClient>();
 
   this->rtcClientList.push_back(nxt);

--- a/tst/mocks/mocksoftwaremanager.hpp
+++ b/tst/mocks/mocksoftwaremanager.hpp
@@ -10,7 +10,7 @@ public:
     SoftwareManager(),
     rtcClientList() {}
 
-  virtual std::weak_ptr<Lineside::RTCClient> GetRTCClient() override;
+  virtual std::shared_ptr<Lineside::RTCClient> GetRTCClient() override;
   
   std::vector<std::shared_ptr<MockRTCClient>> rtcClientList;
 };


### PR DESCRIPTION
Have the `SoftwareManager` return `std::shared_ptr<RTCClient>` rather than a weak pointer. The latter simply added complication.