### PR TITLE
Return reference to PWItemModel

### DIFF
--- a/apps/signals/runonconsole.cpp
+++ b/apps/signals/runonconsole.cpp
@@ -66,13 +66,9 @@ void RunOnConsole(Lineside::PWItemManager& pwItemManager) {
       try {
 	target.Parse(tokens.at(0));
 
-	auto pwItem = pwItemManager.GetPWItemModelById(target);
-	LOCK_OR_THROW( pwItemShared, pwItem );
-	auto mash = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>( pwItemShared );
-	if( !mash ) {
-	  throw std::logic_error("Not a MultiAspectSignalHead");
-	}
-	HandleMASH( *mash, tokens );
+	Lineside::PWItemModel& pwItem = pwItemManager.GetPWItemModelById(target);
+	Lineside::MultiAspectSignalHead& mash = dynamic_cast<Lineside::MultiAspectSignalHead&>(pwItem);
+	HandleMASH( mash, tokens );
       }
       catch( std::exception& e ) {
 	std::cerr << e.what() << std::endl;

--- a/include/pwitemcontroller.hpp
+++ b/include/pwitemcontroller.hpp
@@ -33,7 +33,7 @@ namespace Lineside {
 			const bool notification) override;
 
     //! Get the associated PWItemModel
-    std::weak_ptr<PWItemModel> GetModel() const;
+    PWItemModel& GetModel() const;
 
     //! Create a PWItemController for the supplied model
     static std::shared_ptr<PWItemController> Construct(std::shared_ptr<PWItemModel> pwim);

--- a/include/pwitemmanager.hpp
+++ b/include/pwitemmanager.hpp
@@ -25,7 +25,7 @@ namespace Lineside {
 
     void CreatePWItems( const std::vector<std::shared_ptr<PWItemData>>& itemData );
 
-    std::weak_ptr<PWItemModel> GetPWItemModelById( const ItemId id ) const;
+    PWItemModel& GetPWItemModelById( const ItemId id ) const;
 
   private:
     std::shared_ptr<HardwareManager> hwManager;

--- a/src/pwitemcontroller.cpp
+++ b/src/pwitemcontroller.cpp
@@ -97,7 +97,7 @@ namespace Lineside {
     return shouldWake;
   }
 
-  std::weak_ptr<PWItemModel> PWItemController::GetModel() const {
-    return this->model;
+  PWItemModel& PWItemController::GetModel() const {
+    return *(this->model);
   }
 }

--- a/src/pwitemmanager.cpp
+++ b/src/pwitemmanager.cpp
@@ -29,7 +29,7 @@ namespace Lineside {
     }
   }
 
-  std::weak_ptr<PWItemModel> PWItemManager::GetPWItemModelById( const ItemId id ) const {
+  PWItemModel& PWItemManager::GetPWItemModelById( const ItemId id ) const {
     if( this->pwItems.count(id) != 1 ) {
       throw KeyNotFoundException(id.ToString());
     }

--- a/tst/pwitemmanagertests.cpp
+++ b/tst/pwitemmanagertests.cpp
@@ -1,4 +1,5 @@
 #include <boost/test/unit_test.hpp>
+#include <boost/predef.h>
 
 #include "multiaspectsignalheaddata.hpp"
 #include "multiaspectsignalhead.hpp"
@@ -64,12 +65,21 @@ BOOST_AUTO_TEST_CASE(SingleMASH)
     BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
     
     // Check we can get the MASH
-    auto resWeak = im.GetPWItemModelById( id );
-    LOCK_OR_THROW( res, resWeak );
-    BOOST_REQUIRE( res );
-    BOOST_CHECK_EQUAL( res->getId(), id );
-    auto resMASH = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHead>( res );
-    BOOST_REQUIRE( resMASH );
+    Lineside::PWItemModel& res = im.GetPWItemModelById(id);
+    BOOST_CHECK_EQUAL( res.getId(), id );
+#if defined(BOOST_COMP_GNUC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
+#elif defined(BOOST_COMP_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
+#endif
+    BOOST_CHECK_NO_THROW( dynamic_cast<Lineside::MultiAspectSignalHead&>(res) );
+#if defined(BOOST_COMP_GNUC)
+#pragma GCC diagnostic pop
+#elif defined(BOOST_COMP_CLANG)
+#pragma clang diagnostic pop
+#endif
   }
 
   // After destruct, both pins should be off
@@ -106,12 +116,21 @@ BOOST_AUTO_TEST_CASE(SingleSTM)
   BOOST_CHECK_EQUAL( pwmChannel->Get(), straight );
 
   // Check we can get the STM
-  auto resWeak = im.GetPWItemModelById( id );
-  LOCK_OR_THROW( res, resWeak );
-  BOOST_REQUIRE( res );
-  BOOST_CHECK_EQUAL( res->getId(), id );
-  auto resSTM = std::dynamic_pointer_cast<Lineside::ServoTurnoutMotor>( res );
-  BOOST_REQUIRE( resSTM );
+  Lineside::PWItemModel& res = im.GetPWItemModelById(id);
+  BOOST_CHECK_EQUAL( res.getId(), id );
+#if defined(BOOST_COMP_GNUC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
+#elif defined(BOOST_COMP_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
+#endif
+  BOOST_CHECK_NO_THROW( dynamic_cast<Lineside::ServoTurnoutMotor&>(res) );
+#if defined(BOOST_COMP_GNUC)
+#pragma GCC diagnostic pop
+#elif defined(BOOST_COMP_CLANG)
+#pragma clang diagnostic pop
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(DuplicateId)


### PR DESCRIPTION
Have `PWItemController` return a reference to its `PWItemModel` rather than a `std::weak_ptr` (which just created extra work).