### PR TITLE
Make hardware unique

### DIFF
--- a/include/hardwareprovider.hpp
+++ b/include/hardwareprovider.hpp
@@ -16,7 +16,7 @@ namespace Lineside {
 
     virtual ~HardwareProvider() {}
 
-    virtual std::shared_ptr<Hardware> GetHardware(const std::string& hardwareId,
+    virtual std::unique_ptr<Hardware> GetHardware(const std::string& hardwareId,
 						  const std::map<std::string,std::string>& settings) = 0;
   };
 }

--- a/include/multiaspectsignalhead.hpp
+++ b/include/multiaspectsignalhead.hpp
@@ -48,12 +48,12 @@ namespace Lineside {
 
     bool lastFlashStatus;
     
-    std::shared_ptr<BinaryOutputPin> red;
-    std::shared_ptr<BinaryOutputPin> yellow1;
-    std::shared_ptr<BinaryOutputPin> yellow2;
-    std::shared_ptr<BinaryOutputPin> green;
+    std::unique_ptr<BinaryOutputPin> red;
+    std::unique_ptr<BinaryOutputPin> yellow1;
+    std::unique_ptr<BinaryOutputPin> yellow2;
+    std::unique_ptr<BinaryOutputPin> green;
     
-    std::vector<std::shared_ptr<BinaryOutputPin>> feathers;
+    std::vector<std::unique_ptr<BinaryOutputPin>> feathers;
 
     MultiAspectSignalHead(const ItemId signalHeadId) :
       PWItemModel(signalHeadId),

--- a/include/multiaspectsignalheaddata.hpp
+++ b/include/multiaspectsignalheaddata.hpp
@@ -25,7 +25,7 @@ namespace Lineside {
 						   SoftwareManager& sw ) const override;
 
   private:
-    std::shared_ptr<BinaryOutputPin> FetchBOP(HardwareManager& hw,
+    std::unique_ptr<BinaryOutputPin> FetchBOP(HardwareManager& hw,
 					      const DeviceRequestData& drd ) const;
     
     void PopulateAspects(HardwareManager& hw,

--- a/include/pigpiod/gpioprovider.hpp
+++ b/include/pigpiod/gpioprovider.hpp
@@ -11,7 +11,7 @@ namespace Lineside {
     public:
       GPIOProvider(std::shared_ptr<PiManager> piHardware);
 
-      std::shared_ptr<GPOutput> GetGPOutput(const unsigned char pinId);
+      std::unique_ptr<GPOutput> GetGPOutput(const unsigned char pinId);
     private:
       std::shared_ptr<PiManager> pi;
       std::set<unsigned char> allocatedPins;

--- a/include/pigpiod/gpoutputprovider.hpp
+++ b/include/pigpiod/gpoutputprovider.hpp
@@ -12,7 +12,7 @@ namespace Lineside {
     public:
       GPOutputProvider(std::shared_ptr<GPIOProvider> provider);
 
-      virtual std::shared_ptr<BinaryOutputPin>
+      virtual std::unique_ptr<BinaryOutputPin>
       GetHardware(const std::string& hardwareId,
 		  const std::map<std::string,std::string>& settings) override;
     private:

--- a/include/pigpiod/pimanager.hpp
+++ b/include/pigpiod/pimanager.hpp
@@ -45,7 +45,7 @@ namespace Lineside {
       }
 
       //! Get a GPIOPin for this Pi
-      std::shared_ptr<GPIOPin> GetGPIOPin(const unsigned int pinId);
+      std::unique_ptr<GPIOPin> GetGPIOPin(const unsigned int pinId);
       
       //! Create an instance of PiManager
       /*!

--- a/include/servoturnoutmotor.hpp
+++ b/include/servoturnoutmotor.hpp
@@ -29,7 +29,7 @@ namespace Lineside {
     unsigned int pwmStraight;
     unsigned int pwmCurved;
     TurnoutState desiredState;
-    std::shared_ptr<PWMChannel> servo;
+    std::unique_ptr<PWMChannel> servo;
     std::mutex stateChangeMtx;
 
     ServoTurnoutMotor(const ItemId turnoutId) :

--- a/include/trackcircuitmonitor.hpp
+++ b/include/trackcircuitmonitor.hpp
@@ -42,7 +42,7 @@ namespace Lineside {
 
     std::mutex updateMtx;
     std::atomic<bool> lastNotificationState;
-    std::shared_ptr<BinaryInputPin> monitorPin;
+    std::unique_ptr<BinaryInputPin> monitorPin;
     std::shared_ptr<RTCClient> rtc;
   };
 }

--- a/src/multiaspectsignalheaddata.cpp
+++ b/src/multiaspectsignalheaddata.cpp
@@ -66,7 +66,7 @@ namespace Lineside {
     return result;
   }
 
-  std::shared_ptr<BinaryOutputPin>
+  std::unique_ptr<BinaryOutputPin>
   MultiAspectSignalHeadData::FetchBOP(HardwareManager& hw,
 				      const DeviceRequestData& drd ) const {
     auto bopProvider = hw.bopProviderRegistrar.Retrieve(drd.controller);

--- a/src/pigpiod/gpioprovider.cpp
+++ b/src/pigpiod/gpioprovider.cpp
@@ -9,7 +9,7 @@ namespace Lineside {
       pi(piHardware),
       allocatedPins() {}
 
-    std::shared_ptr<GPOutput> GPIOProvider::GetGPOutput(const unsigned char pinId) {
+    std::unique_ptr<GPOutput> GPIOProvider::GetGPOutput(const unsigned char pinId) {
       if( this->allocatedPins.count(pinId) != 0 ) {
 	// Want to print as number, not character
 	std::stringstream msg;
@@ -17,7 +17,7 @@ namespace Lineside {
 	throw DuplicateKeyException(msg.str());
       }
       
-      auto result = std::make_shared<GPOutput>(this->pi->GetGPIOPin(pinId));
+      auto result = std::unique_ptr<GPOutput>(new GPOutput(this->pi->GetGPIOPin(pinId)));
       this->allocatedPins.insert(pinId);
       return result;
     }

--- a/src/pigpiod/gpoutputprovider.cpp
+++ b/src/pigpiod/gpoutputprovider.cpp
@@ -7,7 +7,7 @@ namespace Lineside {
       gpioProvider(provider) {}
 
     
-    std::shared_ptr<BinaryOutputPin>
+    std::unique_ptr<BinaryOutputPin>
     GPOutputProvider::GetHardware(const std::string& hardwareId,
 				  const std::map<std::string,std::string>& settings) {
       if( settings.size() != 0 ) {

--- a/src/pigpiod/pimanager.cpp
+++ b/src/pigpiod/pimanager.cpp
@@ -33,8 +33,8 @@ namespace Lineside {
       PiManager::initialised = false;
     }
 
-    std::shared_ptr<GPIOPin> PiManager::GetGPIOPin(const unsigned int pinId) {
-      return std::make_shared<GPIOPin>(this->shared_from_this(), pinId);
+    std::unique_ptr<GPIOPin> PiManager::GetGPIOPin(const unsigned int pinId) {
+      return std::unique_ptr<GPIOPin>(new GPIOPin(this->shared_from_this(), pinId));
     }
 
     std::shared_ptr<PiManager> PiManager::CreatePiManager() {

--- a/src/servoturnoutmotordata.cpp
+++ b/src/servoturnoutmotordata.cpp
@@ -16,7 +16,7 @@ namespace Lineside {
     this->UnusedSoftwareManager(sw);
     
     auto pwmChannelProvider = hw.pwmcProviderRegistrar.Retrieve(this->pwmChannelRequest.controller);
-    std::shared_ptr<PWMChannel> servo;
+    std::unique_ptr<PWMChannel> servo;
     servo = pwmChannelProvider->GetHardware(this->pwmChannelRequest.controllerData,
 					    this->pwmChannelRequest.settings);
     
@@ -29,7 +29,7 @@ namespace Lineside {
     auto result = std::make_shared<enabler>(this->id);
     result->pwmStraight = this->straight;
     result->pwmCurved = this->curved;
-    result->servo = servo;
+    result->servo = std::move(servo);
 
     return result;
   }

--- a/src/trackcircuitmonitordata.cpp
+++ b/src/trackcircuitmonitordata.cpp
@@ -21,7 +21,7 @@ namespace Lineside {
 
     // Link up the input pin
     bip->RegisterListener(this->id.Get(), result);
-    result->monitorPin = bip;
+    result->monitorPin = std::move(bip);
 
     // Get RTC client
     result->rtc = sw.GetRTCClient();

--- a/tst/gpoutputprovidertests.cpp
+++ b/tst/gpoutputprovidertests.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE( GetPin )
   // Should start with pin in off state
   BOOST_CHECK_EQUAL( bop->Get(), false );
 
-  auto gpbop = std::dynamic_pointer_cast<Lineside::PiGPIOd::GPOutput>(bop);
+  auto gpbop = dynamic_cast<Lineside::PiGPIOd::GPOutput*>(bop.get());
   BOOST_REQUIRE(gpbop);
 }
 

--- a/tst/mockbipprovidertests.cpp
+++ b/tst/mockbipprovidertests.cpp
@@ -15,11 +15,11 @@ BOOST_AUTO_TEST_CASE(ConstructOne)
   const std::string channelId = "01";
   const std::map<std::string,std::string> settings;
 
-  auto sbop = mbb.GetHardware(channelId, settings);
+  auto bop = mbb.GetHardware(channelId, settings);
   BOOST_CHECK_EQUAL( mbb.pins.size(), 1 );
-  auto sharedFromProvider = mbb.pins.at(channelId);
+  auto fromProvider = mbb.pins.at(channelId);
 
-  BOOST_CHECK_EQUAL( sbop.get(), sharedFromProvider.get() );
+  BOOST_CHECK_EQUAL( bop.get(), fromProvider );
 }
 
 BOOST_AUTO_TEST_CASE(ConstructTwo)
@@ -31,11 +31,11 @@ BOOST_AUTO_TEST_CASE(ConstructTwo)
   const std::string ch02 = "012";
   const std::map<std::string,std::string> settings;
 
-  auto sbop1 = mbb.GetHardware(ch01, settings);
-  auto sbop2 = mbb.GetHardware(ch02, settings);
+  auto bop1 = mbb.GetHardware(ch01, settings);
+  auto bop2 = mbb.GetHardware(ch02, settings);
 
   BOOST_CHECK_EQUAL( mbb.pins.size(), 2 );
-  BOOST_CHECK_NE( sbop1.get(), sbop2.get() );
+  BOOST_CHECK_NE( bop1.get(), bop2.get() );
 }
 
 BOOST_AUTO_TEST_CASE(NoDoubleRequest)

--- a/tst/mockbopprovidertests.cpp
+++ b/tst/mockbopprovidertests.cpp
@@ -15,11 +15,11 @@ BOOST_AUTO_TEST_CASE(ConstructOne)
   const std::string channelId = "01";
   const std::map<std::string,std::string> settings;
 
-  auto sbop = mbb.GetHardware(channelId, settings);
+  auto bop = mbb.GetHardware(channelId, settings);
   BOOST_CHECK_EQUAL( mbb.pins.size(), 1 );
-  auto sharedFromProvider = mbb.pins.at(channelId);
+  auto fromProvider = mbb.pins.at(channelId);
 
-  BOOST_CHECK_EQUAL( sbop.get(), sharedFromProvider.get() );
+  BOOST_CHECK_EQUAL( bop.get(), fromProvider );
 }
 
 BOOST_AUTO_TEST_CASE(ConstructTwo)
@@ -31,11 +31,11 @@ BOOST_AUTO_TEST_CASE(ConstructTwo)
   const std::string ch02 = "012";
   const std::map<std::string,std::string> settings;
 
-  auto sbop1 = mbb.GetHardware(ch01, settings);
-  auto sbop2 = mbb.GetHardware(ch02, settings);
+  auto bop1 = mbb.GetHardware(ch01, settings);
+  auto bop2 = mbb.GetHardware(ch02, settings);
 
   BOOST_CHECK_EQUAL( mbb.pins.size(), 2 );
-  BOOST_CHECK_NE( sbop1.get(), sbop2.get() );
+  BOOST_CHECK_NE( bop1.get(), bop2.get() );
 }
 
 BOOST_AUTO_TEST_CASE(NoDoubleRequest)
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(NoDoubleRequest)
   const std::string chId = "01";
   const std::map<std::string,std::string> settings;
 
-  auto spc = mbb.GetHardware(chId, settings);
+  auto bop = mbb.GetHardware(chId, settings);
 
   std::string msg("Key '01' already present");
   BOOST_CHECK_EXCEPTION( mbb.GetHardware(chId, settings),

--- a/tst/mockpwmchannelprovidertests.cpp
+++ b/tst/mockpwmchannelprovidertests.cpp
@@ -14,11 +14,11 @@ BOOST_AUTO_TEST_CASE(ConstructOne)
   const std::string channelId = "01";
   const std::map<std::string,std::string> settings;
 
-  auto spc = mcp.GetHardware(channelId, settings);
+  auto pc = mcp.GetHardware(channelId, settings);
   BOOST_CHECK_EQUAL( mcp.channels.size(), 1 );
-  auto sharedFromProvider = mcp.channels.at(channelId);
+  auto fromProvider = mcp.channels.at(channelId);
   
-  BOOST_CHECK_EQUAL( spc.get(), sharedFromProvider.get() );
+  BOOST_CHECK_EQUAL( pc.get(), fromProvider );
 }
 
 BOOST_AUTO_TEST_CASE(ConstructTwo)
@@ -29,11 +29,11 @@ BOOST_AUTO_TEST_CASE(ConstructTwo)
    const std::string ch02 = "02";
    const std::map<std::string,std::string> settings;
 
-   auto spc1 = mcp.GetHardware(ch01, settings);
-   auto spc2 = mcp.GetHardware(ch02, settings);
+   auto pc1 = mcp.GetHardware(ch01, settings);
+   auto pc2 = mcp.GetHardware(ch02, settings);
 
    BOOST_CHECK_EQUAL( mcp.channels.size(), 2 );
-   BOOST_CHECK_NE( spc1.get(), spc2.get() );
+   BOOST_CHECK_NE( pc1.get(), pc2.get() );
 }
 
 BOOST_AUTO_TEST_CASE(NoDoubleRequest)
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(NoDoubleRequest)
   const std::string chId = "01";
   const std::map<std::string,std::string> settings;
 
-  auto spc = mcp.GetHardware(chId, settings);
+  auto pc = mcp.GetHardware(chId, settings);
 
   std::string msg("Key '01' already present");
   BOOST_CHECK_EXCEPTION( mcp.GetHardware(chId, settings),

--- a/tst/mocks/mockbipprovider.cpp
+++ b/tst/mocks/mockbipprovider.cpp
@@ -2,8 +2,9 @@
 
 #include "mockbipprovider.hpp"
 
-std::shared_ptr<Lineside::BinaryInputPin> MockBIPProvider::GetHardware(const std::string& hardwareId,
-								       const std::map<std::string,std::string>& settings) {
+std::unique_ptr<Lineside::BinaryInputPin>
+MockBIPProvider::GetHardware(const std::string& hardwareId,
+			     const std::map<std::string,std::string>& settings) {
   if( settings.size() != 0 ) {
     std::stringstream msg;
     msg << "MockBIP request for "
@@ -16,7 +17,7 @@ std::shared_ptr<Lineside::BinaryInputPin> MockBIPProvider::GetHardware(const std
     throw Lineside::DuplicateKeyException(hardwareId);
   }
 
-  auto result = std::make_shared<MockBIP>();
-  this->pins[hardwareId] = result;
+  auto result = std::unique_ptr<MockBIP>(new MockBIP());
+  this->pins[hardwareId] = result.get();
   return result;
 }

--- a/tst/mocks/mockbipprovider.hpp
+++ b/tst/mocks/mockbipprovider.hpp
@@ -12,8 +12,9 @@ public:
     HardwareProvider(),
     pins() {}
 
-  virtual std::shared_ptr<Lineside::BinaryInputPin> GetHardware(const std::string& hardwareId,
+  virtual std::unique_ptr<Lineside::BinaryInputPin> GetHardware(const std::string& hardwareId,
 								const std::map<std::string,std::string>& settings) override;
 
-  std::map<std::string,std::shared_ptr<MockBIP>> pins;
+  // Allow access to the created pins (dangerously)
+  std::map<std::string,MockBIP*> pins;
 };

--- a/tst/mocks/mockbopprovider.cpp
+++ b/tst/mocks/mockbopprovider.cpp
@@ -2,8 +2,9 @@
 
 #include "mockbopprovider.hpp"
 
-std::shared_ptr<Lineside::BinaryOutputPin> MockBOPProvider::GetHardware(const std::string& hardwareId,
-									const std::map<std::string,std::string>& settings) {
+std::unique_ptr<Lineside::BinaryOutputPin>
+MockBOPProvider::GetHardware(const std::string& hardwareId,
+			     const std::map<std::string,std::string>& settings) {
   if( settings.size() != 0 ) {
     std::stringstream msg;
     msg << "MockBOP request for "
@@ -16,7 +17,7 @@ std::shared_ptr<Lineside::BinaryOutputPin> MockBOPProvider::GetHardware(const st
     throw Lineside::DuplicateKeyException(hardwareId);
   }
 
-  auto result = std::make_shared<MockBOP>();
-  this->pins[hardwareId] = result;
+  auto result = std::unique_ptr<MockBOP>(new MockBOP());
+  this->pins[hardwareId] = result.get();
   return result;
 }

--- a/tst/mocks/mockbopprovider.hpp
+++ b/tst/mocks/mockbopprovider.hpp
@@ -12,8 +12,9 @@ public:
     HardwareProvider(),
     pins() {}
 
-  virtual std::shared_ptr<Lineside::BinaryOutputPin> GetHardware(const std::string& hardwareId,
+  virtual std::unique_ptr<Lineside::BinaryOutputPin> GetHardware(const std::string& hardwareId,
 								 const std::map<std::string,std::string>& settings) override;
 
-  std::map<std::string,std::shared_ptr<MockBOP>> pins;
+  // Allow dangerous access to the returned resources
+  std::map<std::string,MockBOP*> pins;
 };

--- a/tst/mocks/mockpwmchannelprovider.cpp
+++ b/tst/mocks/mockpwmchannelprovider.cpp
@@ -4,8 +4,9 @@
 
 #include "mockpwmchannelprovider.hpp"
 
-std::shared_ptr<Lineside::PWMChannel> MockPWMChannelProvider::GetHardware(const std::string& hardwareId,
-									  const std::map<std::string,std::string>& settings) {
+std::unique_ptr<Lineside::PWMChannel>
+MockPWMChannelProvider::GetHardware(const std::string& hardwareId,
+				    const std::map<std::string,std::string>& settings) {
   if( settings.size() != 0 ) {
     std::stringstream msg;
     msg << "MockPWMChannel request for "
@@ -18,7 +19,7 @@ std::shared_ptr<Lineside::PWMChannel> MockPWMChannelProvider::GetHardware(const 
     throw Lineside::DuplicateKeyException(hardwareId);
   }
   
-  auto result = std::make_shared<MockPWMChannel>();
-  this->channels[hardwareId] = result;
+  auto result = std::unique_ptr<MockPWMChannel>(new MockPWMChannel());
+  this->channels[hardwareId] = result.get();
   return result;
 }

--- a/tst/mocks/mockpwmchannelprovider.hpp
+++ b/tst/mocks/mockpwmchannelprovider.hpp
@@ -12,8 +12,9 @@ public:
     HardwareProvider(),
     channels() {}
   
-  virtual std::shared_ptr<Lineside::PWMChannel> GetHardware(const std::string& hardwareId,
+  virtual std::unique_ptr<Lineside::PWMChannel> GetHardware(const std::string& hardwareId,
 							    const std::map<std::string,std::string>& settings) override;
 
-  std::map<std::string,std::shared_ptr<MockPWMChannel>> channels;
+  // Allow dangerous access to the allocated channels
+  std::map<std::string,MockPWMChannel*> channels;
 };

--- a/tst/pihardwaremanagertests.cpp
+++ b/tst/pihardwaremanagertests.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE( Smoke )
   // Should start with pin in off state
   BOOST_CHECK_EQUAL( pin->Get(), false );
 
-  auto gpbop = std::dynamic_pointer_cast<Lineside::PiGPIOd::GPOutput>(pin);
+  auto gpbop = dynamic_cast<Lineside::PiGPIOd::GPOutput*>(pin.get());
   BOOST_REQUIRE(gpbop);
 }
 

--- a/tst/pwitemmanagertests.cpp
+++ b/tst/pwitemmanagertests.cpp
@@ -54,19 +54,18 @@ BOOST_AUTO_TEST_CASE(SingleMASH)
   std::vector<std::shared_ptr<Lineside::PWItemData>> itemList;
   itemList.push_back(mashd);
 
-  {
-    Lineside::PWItemManager im(this->hwManager, this->swManager);
-
-    // Create the MASH
-    im.CreatePWItems( itemList );
-    
-    // The MASH should be showing a Red aspect
-    BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
-    BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
-    
-    // Check we can get the MASH
-    Lineside::PWItemModel& res = im.GetPWItemModelById(id);
-    BOOST_CHECK_EQUAL( res.getId(), id );
+  Lineside::PWItemManager im(this->hwManager, this->swManager);
+  
+  // Create the MASH
+  im.CreatePWItems( itemList );
+  
+  // The MASH should be showing a Red aspect
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), true );
+  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
+  
+  // Check we can get the MASH
+  Lineside::PWItemModel& res = im.GetPWItemModelById(id);
+  BOOST_CHECK_EQUAL( res.getId(), id );
 #if defined(BOOST_COMP_GNUC)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-value"
@@ -74,17 +73,12 @@ BOOST_AUTO_TEST_CASE(SingleMASH)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-value"
 #endif
-    BOOST_CHECK_NO_THROW( dynamic_cast<Lineside::MultiAspectSignalHead&>(res) );
+  BOOST_CHECK_NO_THROW( dynamic_cast<Lineside::MultiAspectSignalHead&>(res) );
 #if defined(BOOST_COMP_GNUC)
 #pragma GCC diagnostic pop
 #elif defined(BOOST_COMP_CLANG)
 #pragma clang diagnostic pop
 #endif
-  }
-
-  // After destruct, both pins should be off
-  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(redData)->Get(), false );
-  BOOST_CHECK_EQUAL( this->hwManager->bopProvider->pins.at(greenData)->Get(), false );
 }
 
 BOOST_AUTO_TEST_CASE(SingleSTM)


### PR DESCRIPTION
Have the `HardwareProvider` class return `std::unique_ptr`s to the hardware abstractions, since each should be owned by exactly one permanent way item.

A consequence of this is that the various mock providers are now 'dangerous' in the sense that the pointers they keep to the hardware allocated are raw pointers, which will become invalid if the corresponding hardware is deleted. For this reason, one of the tests for the `PWItemManager` has had to lose its checks that the destructors did turned off pins.