### PR TITLE
Add Input Pin support for pigpiod

### DIFF
--- a/include/pigpiod/gpinput.hpp
+++ b/include/pigpiod/gpinput.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "binaryinputpin.hpp"
+
+#include "pigpiod/gpiopin.hpp"
+
+namespace Lineside {
+  namespace PiGPIOd {
+    class GPInput : public BinaryInputPin {
+    public:
+      GPInput(std::unique_ptr<GPIOPin> piPin,
+	      GPIOPull pull,
+	      unsigned int glitchSteadyMicroseconds,
+	      GPIOEdge callbackEdge);
+
+      virtual bool Get() const override;
+
+      void ReceiveUpdate(const bool level);
+    private:
+      std::unique_ptr<GPIOPin> pin;
+    };
+  }
+}

--- a/include/pigpiod/gpinput.hpp
+++ b/include/pigpiod/gpinput.hpp
@@ -9,9 +9,9 @@ namespace Lineside {
     class GPInput : public BinaryInputPin {
     public:
       GPInput(std::unique_ptr<GPIOPin> piPin,
-	      GPIOPull pull,
-	      unsigned int glitchSteadyMicroseconds,
-	      GPIOEdge callbackEdge);
+	      const GPIOPull pull,
+	      const unsigned int glitchSteadyMicroseconds,
+	      const GPIOEdge callBackEdge);
 
       virtual bool Get() const override;
 

--- a/include/pigpiod/gpinputprovider.hpp
+++ b/include/pigpiod/gpinputprovider.hpp
@@ -3,15 +3,15 @@
 #include "hardwareprovider.hpp"
 
 #include "pigpiod/gpioprovider.hpp"
-#include "pigpiod/gpoutput.hpp"
+#include "pigpiod/gpinput.hpp"
 
 namespace Lineside {
   namespace PiGPIOd {
-    class GPOutputProvider : public HardwareProvider<BinaryOutputPin> {
+    class GPInputProvider : public HardwareProvider<BinaryInputPin> {
     public:
-      GPOutputProvider(std::shared_ptr<GPIOProvider> provider);
+      GPInputProvider(std::shared_ptr<GPIOProvider> provider);
 
-      virtual std::unique_ptr<BinaryOutputPin>
+      virtual std::unique_ptr<BinaryInputPin>
       GetHardware(const std::string& hardwareId,
 		  const std::map<std::string,std::string>& settings) override;
     private:

--- a/include/pigpiod/gpinputprovider.hpp
+++ b/include/pigpiod/gpinputprovider.hpp
@@ -9,6 +9,9 @@ namespace Lineside {
   namespace PiGPIOd {
     class GPInputProvider : public HardwareProvider<BinaryInputPin> {
     public:
+      const std::string glitchSetting = "glitch";
+      const std::string pudSetting = "pud";
+      
       GPInputProvider(std::shared_ptr<GPIOProvider> provider);
 
       virtual std::unique_ptr<BinaryInputPin>

--- a/include/pigpiod/gpioedge.hpp
+++ b/include/pigpiod/gpioedge.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifdef HAVE_PIGPIO
+#include <pigpiod_if2.h>
+#else
+#include "pigpiod/pigpiodstubs.hpp"
+#endif
+
+namespace Lineside {
+  namespace PiGPIOd {
+    enum class GPIOEdge {
+			 Rising = RISING_EDGE,
+			 Falling = FALLING_EDGE,
+			 Either = EITHER_EDGE
+    };
+  }
+}

--- a/include/pigpiod/gpiopin.hpp
+++ b/include/pigpiod/gpiopin.hpp
@@ -17,7 +17,7 @@ namespace Lineside {
       /*!
 	Callback functions are invoked with the level of the associated pin.
       */
-      typedef std::function<void(bool)> CallBackFn;
+      typedef std::function<void(const bool)> CallBackFn;
       
       GPIOPin(const std::shared_ptr<PiManager> owner,
 	      const unsigned int pinId);

--- a/include/pigpiod/gpiopin.hpp
+++ b/include/pigpiod/gpiopin.hpp
@@ -5,6 +5,7 @@
 #include "pimanager.hpp"
 
 #include "gpiomode.hpp"
+#include "gpioedge.hpp"
 
 namespace Lineside {
   namespace PiGPIOd {
@@ -15,6 +16,8 @@ namespace Lineside {
       
       GPIOPin(const std::shared_ptr<PiManager> owner,
 	      const unsigned int pinId);
+
+      ~GPIOPin();
 
       int getPi() const {
 	return this->pi->getId();
@@ -29,10 +32,14 @@ namespace Lineside {
       bool Read() const;
       
       void Write(const bool level);
+
+      int SetCallback(GPIOEdge edge, CallBackFn f);
       
     private:
       std::shared_ptr<PiManager> pi;
       const unsigned int pin;
+
+      int callBackId;
     };
   }
 }

--- a/include/pigpiod/gpiopin.hpp
+++ b/include/pigpiod/gpiopin.hpp
@@ -6,6 +6,7 @@
 
 #include "gpiomode.hpp"
 #include "gpioedge.hpp"
+#include "gpiopull.hpp"
 
 namespace Lineside {
   namespace PiGPIOd {
@@ -37,9 +38,11 @@ namespace Lineside {
       
       void Write(const bool level);
 
-      void SetCallBack(GPIOEdge edge, CallBackFn f);
-
+      void SetPUDResistor(GPIOPull pull);
+      
       void SetGlitchFilter(unsigned int steadyMicroseconds);
+
+      void SetCallBack(GPIOEdge edge, CallBackFn f);
 
       void InvokeCallBack(int pi, unsigned user_gpio, unsigned level, uint32_t tick);
       

--- a/include/pigpiod/gpiopin.hpp
+++ b/include/pigpiod/gpiopin.hpp
@@ -33,12 +33,13 @@ namespace Lineside {
       
       void Write(const bool level);
 
-      int SetCallback(GPIOEdge edge, CallBackFn f);
+      void SetCallback(GPIOEdge edge, CallBackFn f);
       
     private:
       std::shared_ptr<PiManager> pi;
       const unsigned int pin;
 
+      CallBackFn callBack;
       int callBackId;
     };
   }

--- a/include/pigpiod/gpiopin.hpp
+++ b/include/pigpiod/gpiopin.hpp
@@ -12,7 +12,11 @@ namespace Lineside {
     //! Class for controlling a GPIO pin
     class GPIOPin {
     public:
-      typedef std::function<void(int,unsigned int,unsigned int, uint32_t)> CallBackFn;
+      //! Define the type of callback functions we accept
+      /*!
+	Callback functions are invoked with the level of the associated pin.
+      */
+      typedef std::function<void(bool)> CallBackFn;
       
       GPIOPin(const std::shared_ptr<PiManager> owner,
 	      const unsigned int pinId);
@@ -34,6 +38,10 @@ namespace Lineside {
       void Write(const bool level);
 
       void SetCallback(GPIOEdge edge, CallBackFn f);
+
+      void SetGlitchFilter(unsigned int steadyMicroseconds);
+
+      void InvokeCallBack(int pi, unsigned user_gpio, unsigned level, uint32_t tick);
       
     private:
       std::shared_ptr<PiManager> pi;

--- a/include/pigpiod/gpiopin.hpp
+++ b/include/pigpiod/gpiopin.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "pimanager.hpp"
 
 #include "gpiomode.hpp"
@@ -9,6 +11,8 @@ namespace Lineside {
     //! Class for controlling a GPIO pin
     class GPIOPin {
     public:
+      typedef std::function<void(int,unsigned int,unsigned int, uint32_t)> CallBackFn;
+      
       GPIOPin(const std::shared_ptr<PiManager> owner,
 	      const unsigned int pinId);
 

--- a/include/pigpiod/gpiopin.hpp
+++ b/include/pigpiod/gpiopin.hpp
@@ -37,7 +37,7 @@ namespace Lineside {
       
       void Write(const bool level);
 
-      void SetCallback(GPIOEdge edge, CallBackFn f);
+      void SetCallBack(GPIOEdge edge, CallBackFn f);
 
       void SetGlitchFilter(unsigned int steadyMicroseconds);
 

--- a/include/pigpiod/gpioprovider.hpp
+++ b/include/pigpiod/gpioprovider.hpp
@@ -4,6 +4,7 @@
 
 #include "pigpiod/pimanager.hpp"
 #include "pigpiod/gpoutput.hpp"
+#include "pigpiod/gpinput.hpp"
 
 namespace Lineside {
   namespace PiGPIOd {
@@ -12,9 +13,15 @@ namespace Lineside {
       GPIOProvider(std::shared_ptr<PiManager> piHardware);
 
       std::unique_ptr<GPOutput> GetGPOutput(const unsigned char pinId);
+      std::unique_ptr<GPInput> GetGPInput(const unsigned char pinId,
+					  const GPIOPull pull,
+					  const unsigned int glitchSteadyMicroseconds,
+					  const GPIOEdge callBackEdge);
     private:
       std::shared_ptr<PiManager> pi;
       std::set<unsigned char> allocatedPins;
+
+      void ReservePin(const unsigned char pinId);
     };
   }
 }

--- a/include/pigpiod/gpiopull.hpp
+++ b/include/pigpiod/gpiopull.hpp
@@ -6,12 +6,23 @@
 #include "pigpiod/pigpiodstubs.hpp"
 #endif
 
+#include "parse.hpp"
+
 namespace Lineside {
   namespace PiGPIOd {
+    //! Enumeration of possibilities for the pullup/pulldown resistor on an input pin
     enum class GPIOPull {
 			 Off = PI_PUD_OFF,
 			 Down = PI_PUD_DOWN,
-			 UP = PI_PUD_UP
+			 Up = PI_PUD_UP
     };
+
+    std::ostream& operator<<( std::ostream& os, const GPIOPull p );
+  
+    std::string ToString( const GPIOPull p );
   }
+  
+  //! Template specialisation to parse a string to a GPIOPull
+  template<>
+  PiGPIOd::GPIOPull Parse<PiGPIOd::GPIOPull>(const std::string& src);
 }

--- a/include/pigpiod/gpiopull.hpp
+++ b/include/pigpiod/gpiopull.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifdef HAVE_PIGPIO
+#include <pigpiod_if2.h>
+#else
+#include "pigpiod/pigpiodstubs.hpp"
+#endif
+
+namespace Lineside {
+  namespace PiGPIOd {
+    enum class GPIOPull {
+			 Off = PI_PUD_OFF,
+			 Down = PI_PUD_DOWN,
+			 UP = PI_PUD_UP
+    };
+  }
+}

--- a/include/pigpiod/gpoutput.hpp
+++ b/include/pigpiod/gpoutput.hpp
@@ -4,19 +4,18 @@
 
 #include "pigpiod/gpiopin.hpp"
 
-
 namespace Lineside {
   namespace PiGPIOd {
     class GPOutput : public BinaryOutputPin {
     public:
-      GPOutput(std::shared_ptr<GPIOPin> piPin);
+      GPOutput(std::unique_ptr<GPIOPin> piPin);
 
       virtual void Set(const bool level) override;
 
       virtual bool Get() const override;
       
     private:
-      std::shared_ptr<GPIOPin> pin;
+      std::unique_ptr<GPIOPin> pin;
     };
   }
 }

--- a/include/pigpiod/pigpiodstubs.hpp
+++ b/include/pigpiod/pigpiodstubs.hpp
@@ -17,6 +17,28 @@ extern std::ostream* pigpiodOS;
 
 #define PI_BAD_GPIO -3
 
+#define RISING_EDGE  0
+#define FALLING_EDGE 1
+#define EITHER_EDGE  2
+
+typedef enum
+{
+   pigif_bad_send           = -2000,
+   pigif_bad_recv           = -2001,
+   pigif_bad_getaddrinfo    = -2002,
+   pigif_bad_connect        = -2003,
+   pigif_bad_socket         = -2004,
+   pigif_bad_noib           = -2005,
+   pigif_duplicate_callback = -2006,
+   pigif_bad_malloc         = -2007,
+   pigif_bad_callback       = -2008,
+   pigif_notify_failed      = -2009,
+   pigif_callback_not_found = -2010,
+   pigif_unconnected_pi     = -2011,
+   pigif_too_many_pis       = -2012,
+} pigifError_t;
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -32,6 +54,16 @@ extern "C" {
   
   int gpio_write(int pi, unsigned gpio, unsigned level);
 
+  typedef void (*CBFunc_t)
+  (int pi, unsigned user_gpio, unsigned level, uint32_t tick);
+
+  typedef void (*CBFuncEx_t)
+  (int pi, unsigned user_gpio, unsigned level, uint32_t tick, void *userdata);
+  
+  int callback_ex(int pi, unsigned user_gpio, unsigned edge, CBFuncEx_t f, void *userdata);
+  
+  int callback_cancel(unsigned callback_id);
+  
   // ===================================================
   
   char *pigpio_error(int errnum);

--- a/include/pigpiod/pigpiodstubs.hpp
+++ b/include/pigpiod/pigpiodstubs.hpp
@@ -1,5 +1,6 @@
 /** \file
- * Stubs for use on a machine without PiGPIOd
+    Stubs for use on a machine without PiGPIOd. The contents of this file are copied
+    from the headers for pigpiod
  */
 #pragma once
 
@@ -20,6 +21,10 @@ extern std::ostream* pigpiodOS;
 #define RISING_EDGE  0
 #define FALLING_EDGE 1
 #define EITHER_EDGE  2
+
+#define PI_PUD_OFF  0
+#define PI_PUD_DOWN 1
+#define PI_PUD_UP   2
 
 typedef enum
 {
@@ -54,6 +59,8 @@ extern "C" {
   
   int gpio_write(int pi, unsigned gpio, unsigned level);
 
+  int set_pull_up_down(int pi, unsigned gpio, unsigned pud);
+  
   int set_glitch_filter(int pi, unsigned user_gpio, unsigned steady);
   
   typedef void (*CBFuncEx_t)

--- a/include/pigpiod/pigpiodstubs.hpp
+++ b/include/pigpiod/pigpiodstubs.hpp
@@ -54,9 +54,8 @@ extern "C" {
   
   int gpio_write(int pi, unsigned gpio, unsigned level);
 
-  typedef void (*CBFunc_t)
-  (int pi, unsigned user_gpio, unsigned level, uint32_t tick);
-
+  int set_glitch_filter(int pi, unsigned user_gpio, unsigned steady);
+  
   typedef void (*CBFuncEx_t)
   (int pi, unsigned user_gpio, unsigned level, uint32_t tick, void *userdata);
   

--- a/include/pigpiod/pihardwaremanager.hpp
+++ b/include/pigpiod/pihardwaremanager.hpp
@@ -5,7 +5,6 @@
 
 #include "pigpiod/pimanager.hpp"
 #include "pigpiod/gpioprovider.hpp"
-#include "pigpiod/gpoutputprovider.hpp"
 
 namespace Lineside {
   namespace PiGPIOd {

--- a/src/pigpiod/CMakeLists.txt
+++ b/src/pigpiod/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND srcs gpoutput.cpp)
 list(APPEND srcs gpinput.cpp)
 list(APPEND srcs gpioprovider.cpp)
 list(APPEND srcs gpoutputprovider.cpp)
+list(APPEND srcs gpinputprovider.cpp)
 
 list(APPEND srcs pihardwaremanager.cpp)
 

--- a/src/pigpiod/CMakeLists.txt
+++ b/src/pigpiod/CMakeLists.txt
@@ -7,6 +7,8 @@ endif()
 list(APPEND srcs pimanager.cpp)
 list(APPEND srcs gpiopin.cpp)
 
+list(APPEND srcs gpiopull.cpp)
+
 list(APPEND srcs gpoutput.cpp)
 list(APPEND srcs gpinput.cpp)
 list(APPEND srcs gpioprovider.cpp)

--- a/src/pigpiod/CMakeLists.txt
+++ b/src/pigpiod/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND srcs pimanager.cpp)
 list(APPEND srcs gpiopin.cpp)
 
 list(APPEND srcs gpoutput.cpp)
+list(APPEND srcs gpinput.cpp)
 list(APPEND srcs gpioprovider.cpp)
 list(APPEND srcs gpoutputprovider.cpp)
 

--- a/src/pigpiod/gpinput.cpp
+++ b/src/pigpiod/gpinput.cpp
@@ -1,0 +1,42 @@
+#include <boost/predef.h>
+
+#include "pigpiod/gpinput.hpp"
+
+namespace Lineside {
+  namespace PiGPIOd {
+    GPInput::GPInput(std::unique_ptr<GPIOPin> piPin,
+		     GPIOPull pull,
+		     unsigned int glitchSteadyMicroseconds,
+		     GPIOEdge callBackEdge) :
+      pin(std::move(piPin)) {
+      this->pin->SetMode(GPIOMode::Input);
+      this->pin->SetPUDResistor(pull);
+      this->pin->SetGlitchFilter(glitchSteadyMicroseconds);
+
+      auto callback = [this](const bool level) {
+			this->ReceiveUpdate(level);
+		      };
+      this->pin->SetCallBack(callBackEdge, callback);
+    }
+    
+#if defined(BOOST_COMP_GNUC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#elif defined(BOOST_COMP_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+    void GPInput::ReceiveUpdate(const bool level) {
+      this->NotifyUpdate();
+    }
+#if defined(BOOST_COMP_GNUC)
+#pragma GCC diagnostic pop
+#elif defined(BOOST_COMP_CLANG)
+#pragma clang diagnostic pop
+#endif
+    
+    bool GPInput::Get() const {
+      return this->pin->Read();
+    }
+  }
+}

--- a/src/pigpiod/gpinputprovider.cpp
+++ b/src/pigpiod/gpinputprovider.cpp
@@ -16,8 +16,12 @@ namespace Lineside {
       unsigned int glitchMicroseconds = 0;
       GPIOEdge callBackEdge = GPIOEdge::Either;
 
-      if( settings.count("glitch") == 1 ) {
-	glitchMicroseconds = std::stoul(settings.at("glitch"));
+      if( settings.count(GPInputProvider::glitchSetting) == 1 ) {
+	glitchMicroseconds = std::stoul(settings.at(GPInputProvider::glitchSetting));
+      }
+
+      if( settings.count(GPInputProvider::pudSetting) == 1 ) {
+	pull = Parse<GPIOPull>(settings.at(GPInputProvider::pudSetting));
       }
       
       return this->gpioProvider->GetGPInput(pinId, pull, glitchMicroseconds, callBackEdge);

--- a/src/pigpiod/gpinputprovider.cpp
+++ b/src/pigpiod/gpinputprovider.cpp
@@ -1,0 +1,26 @@
+#include "pigpiod/gpinputprovider.hpp"
+
+namespace Lineside {
+  namespace PiGPIOd {
+    GPInputProvider::GPInputProvider(std::shared_ptr<GPIOProvider> provider) :
+      HardwareProvider<BinaryInputPin>(),
+      gpioProvider(provider) {}
+
+    
+    std::unique_ptr<BinaryInputPin>
+    GPInputProvider::GetHardware(const std::string& hardwareId,
+				 const std::map<std::string,std::string>& settings) {
+      unsigned char pinId = std::stoul(hardwareId);
+
+      GPIOPull pull = GPIOPull::Off;
+      unsigned int glitchMicroseconds = 0;
+      GPIOEdge callBackEdge = GPIOEdge::Either;
+
+      if( settings.count("glitch") == 1 ) {
+	glitchMicroseconds = std::stoul(settings.at("glitch"));
+      }
+      
+      return this->gpioProvider->GetGPInput(pinId, pull, glitchMicroseconds, callBackEdge);
+    }
+  }
+}

--- a/src/pigpiod/gpinputprovider.cpp
+++ b/src/pigpiod/gpinputprovider.cpp
@@ -1,3 +1,5 @@
+#include <sstream>
+
 #include "pigpiod/gpinputprovider.hpp"
 
 namespace Lineside {
@@ -16,12 +18,22 @@ namespace Lineside {
       unsigned int glitchMicroseconds = 0;
       GPIOEdge callBackEdge = GPIOEdge::Either;
 
+      size_t settingsUsed = 0;
       if( settings.count(GPInputProvider::glitchSetting) == 1 ) {
 	glitchMicroseconds = std::stoul(settings.at(GPInputProvider::glitchSetting));
+	settingsUsed++;
       }
 
       if( settings.count(GPInputProvider::pudSetting) == 1 ) {
 	pull = Parse<GPIOPull>(settings.at(GPInputProvider::pudSetting));
+	settingsUsed++;
+      }
+
+      if( settings.size() != settingsUsed ) {
+	std::stringstream msg;
+	msg << __PRETTY_FUNCTION__
+	    << ": Did not use all entries in settings";
+	throw std::logic_error(msg.str());
       }
       
       return this->gpioProvider->GetGPInput(pinId, pull, glitchMicroseconds, callBackEdge);

--- a/src/pigpiod/gpiopin.cpp
+++ b/src/pigpiod/gpiopin.cpp
@@ -15,7 +15,21 @@ namespace Lineside {
     GPIOPin::GPIOPin(const std::shared_ptr<PiManager> owner,
 		     const unsigned int pinId) :
       pi(owner),
-      pin(pinId) {}
+      pin(pinId),
+      callBackId(-1) {}
+
+    GPIOPin::~GPIOPin() {
+      if( this->callBackId > 0 ) {
+	auto res = callback_cancel(this->callBackId);
+	if( res != 0 ) {
+	  // Can't throw an exception from a destructor
+	  std::clog << __FUNCTION__
+		    << ": callback_cancel failed to find "
+		    << this->callBackId
+		    << std::endl;
+	}
+      }
+    }
 
     void GPIOPin::SetMode(GPIOMode mode) {
       int libraryResult = set_mode(this->pi->getId(),

--- a/src/pigpiod/gpiopin.cpp
+++ b/src/pigpiod/gpiopin.cpp
@@ -1,3 +1,6 @@
+#include <iostream>
+#include <sstream>
+
 #ifdef HAVE_PIGPIO
 #include <pigpiod_if2.h>
 #else
@@ -26,6 +29,7 @@ namespace Lineside {
 		     const unsigned int pinId) :
       pi(owner),
       pin(pinId),
+      callBack(),
       callBackId(-1) {}
 
     GPIOPin::~GPIOPin() {
@@ -84,7 +88,7 @@ namespace Lineside {
     }
 
     void GPIOPin::InvokeCallBack(int pi, unsigned user_gpio, unsigned level, uint32_t tick) {
-      if( (pi != this->getPi()) || (user_gpio != this->getPin()) ) {
+      if( (pi != this->getPi()) || (user_gpio != this->getPin()) || (level > 2) ) {
 	std::stringstream msg;
 	msg << __FUNCTION__
 	    << ": Got invalid args. "
@@ -95,7 +99,15 @@ namespace Lineside {
 	throw std::logic_error(msg.str());
       }
 
-      this->callBack(level);
+      // Note that we already checked for level > 2
+      if( level < 2 ) {
+	this->callBack(level);
+      } else {
+	std::clog << __FUNCTION__
+		  << pi << " "
+		  << user_gpio << " "
+		  << "Level Unchanged" << std::endl;
+      }
     }
   }
 }

--- a/src/pigpiod/gpiopin.cpp
+++ b/src/pigpiod/gpiopin.cpp
@@ -12,6 +12,7 @@
 //! Trampoline function for callbacks
 /*!
   This function exists to permit callbacks from the pigiod library into our code.
+  It assumes that the userdata pointer is actually a pointer to an instance of GPIOPin.
  */
 void CallBackTrampoline(int pi, unsigned user_gpio, unsigned level, uint32_t tick, void *userdata) {
   auto pin = static_cast<Lineside::PiGPIOd::GPIOPin*>(userdata);
@@ -67,6 +68,24 @@ namespace Lineside {
       if( libraryResult != 0 ) {
 	throw PiGPIOdException("gpio_write", libraryResult);
       }
+    }
+
+    void GPIOPin::SetPUDResistor(GPIOPull pull) {
+      int libraryResult = set_pull_up_down(this->pi->getId(),
+					   this->pin,
+					   static_cast<unsigned>(pull));
+      if( libraryResult != 0 ) {
+	throw PiGPIOdException("set_pull_up_down", libraryResult);
+      }    
+    }
+      
+    void GPIOPin::SetGlitchFilter(unsigned int steadyMicroseconds) {
+      int libraryResult = set_glitch_filter(this->pi->getId(),
+					    this->pin,
+					    steadyMicroseconds);
+      if( libraryResult != 0 ) {
+	throw PiGPIOdException("set_glitch_filter", libraryResult);
+      } 
     }
 
     void GPIOPin::SetCallBack(GPIOEdge edge, CallBackFn f) {

--- a/src/pigpiod/gpiopin.cpp
+++ b/src/pigpiod/gpiopin.cpp
@@ -29,7 +29,7 @@ namespace Lineside {
       callBackId(-1) {}
 
     GPIOPin::~GPIOPin() {
-      if( this->callBackId > 0 ) {
+      if( this->callBackId >= 0 ) {
 	auto res = callback_cancel(this->callBackId);
 	if( res != 0 ) {
 	  // Can't throw an exception from a destructor
@@ -69,7 +69,7 @@ namespace Lineside {
       }
     }
 
-    void GPIOPin::SetCallback(GPIOEdge edge, CallBackFn f) {
+    void GPIOPin::SetCallBack(GPIOEdge edge, CallBackFn f) {
       this->callBack = f;
 
       int libraryResult = callback_ex(this->pi->getId(),
@@ -80,6 +80,7 @@ namespace Lineside {
       if( libraryResult < 0 ) {
 	throw PiGPIOdException("callback_ex", libraryResult);
       }
+      this->callBackId = libraryResult;
     }
 
     void GPIOPin::InvokeCallBack(int pi, unsigned user_gpio, unsigned level, uint32_t tick) {

--- a/src/pigpiod/gpioprovider.cpp
+++ b/src/pigpiod/gpioprovider.cpp
@@ -10,16 +10,30 @@ namespace Lineside {
       allocatedPins() {}
 
     std::unique_ptr<GPOutput> GPIOProvider::GetGPOutput(const unsigned char pinId) {
+      this->ReservePin(pinId);
+      return std::unique_ptr<GPOutput>(new GPOutput(this->pi->GetGPIOPin(pinId)));
+    }
+
+    std::unique_ptr<GPInput>
+    GPIOProvider::GetGPInput(const unsigned char pinId,
+			     const GPIOPull pull,
+			     const unsigned int glitchSteadyMicroseconds,
+			     const GPIOEdge callBackEdge) {
+      this->ReservePin(pinId);
+      return std::unique_ptr<GPInput>(new GPInput(this->pi->GetGPIOPin(pinId),
+						  pull,
+						  glitchSteadyMicroseconds,
+						  callBackEdge));
+    }
+
+    void GPIOProvider::ReservePin(const unsigned char pinId) {
       if( this->allocatedPins.count(pinId) != 0 ) {
 	// Want to print as number, not character
 	std::stringstream msg;
 	msg << static_cast<int>(pinId);
 	throw DuplicateKeyException(msg.str());
       }
-      
-      auto result = std::unique_ptr<GPOutput>(new GPOutput(this->pi->GetGPIOPin(pinId)));
       this->allocatedPins.insert(pinId);
-      return result;
     }
   }
 }

--- a/src/pigpiod/gpiopull.cpp
+++ b/src/pigpiod/gpiopull.cpp
@@ -1,0 +1,63 @@
+#include <stdexcept>
+#include <boost/bimap.hpp>
+
+#include "pigpiod/gpiopull.hpp"
+
+namespace Lineside {
+  namespace PiGPIOd {
+    static boost::bimap<GPIOPull,std::string> convertor;
+
+    static void initconvertor() {
+      typedef decltype(convertor)::value_type pos;
+      convertor.insert( pos(GPIOPull::Off, "Off") );
+      convertor.insert( pos(GPIOPull::Down, "Down") );
+      convertor.insert( pos(GPIOPull::Up, "Up") );
+    }
+
+    std::ostream& operator<<( std::ostream& os, const GPIOPull p ) {
+      os << ToString( p );
+      return os;
+    }
+    
+    std::string ToString( const GPIOPull p ) {
+      if( convertor.empty() ) {
+	initconvertor();
+      }
+      
+      std::string res;
+      try {
+	res = convertor.left.at(p);
+      }
+      catch( std::out_of_range& e ) {
+	std::stringstream msg;
+	msg << "Unrecognised GPIOPull: ";
+	msg << static_cast<int>(p);
+	throw std::runtime_error(msg.str());
+      }
+      
+      return res;
+    }
+  }
+
+  template<>
+  PiGPIOd::GPIOPull Parse<PiGPIOd::GPIOPull>(const std::string& src) {
+    if( PiGPIOd::convertor.empty() ) {
+      PiGPIOd::initconvertor();
+    }
+    
+    try {
+      PiGPIOd::GPIOPull pull;
+      pull = PiGPIOd::convertor.right.at(src);
+      return pull;
+    }
+    catch( std::out_of_range& e ) {
+      std::stringstream msg;
+      msg << "Could not parse '";
+      msg << src;
+      msg << "' to GPIOPull";
+      throw std::invalid_argument(msg.str());
+    }
+
+  }
+}
+  

--- a/src/pigpiod/gpoutput.cpp
+++ b/src/pigpiod/gpoutput.cpp
@@ -2,8 +2,8 @@
 
 namespace Lineside {
   namespace PiGPIOd {
-    GPOutput::GPOutput(std::shared_ptr<GPIOPin> piPin) :
-      pin(piPin) {
+    GPOutput::GPOutput(std::unique_ptr<GPIOPin> piPin) :
+      pin(std::move(piPin)) {
       this->pin->SetMode(GPIOMode::Output);
       this->Set(false);
     }

--- a/src/pigpiod/pigpiodstubs.cpp
+++ b/src/pigpiod/pigpiodstubs.cpp
@@ -64,6 +64,22 @@ int gpio_write(int pi, unsigned gpio, unsigned level) {
   return 0;
 }
 
+int set_pull_up_down(int pi, unsigned gpio, unsigned pud) {
+  (*pigpiodOS) << __FUNCTION__
+	       << " " << pi
+	       << " " << gpio
+	       << " " << pud << std::endl;
+  return 0;
+}
+
+int set_glitch_filter(int pi, unsigned user_gpio, unsigned steady) {
+  (*pigpiodOS) << __FUNCTION__
+	       << " " << pi
+	       << " " << user_gpio
+	       << " " << steady << std::endl;
+  return 0;
+}
+
 #if defined(BOOST_COMP_GNUC)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"

--- a/src/pigpiod/pigpiodstubs.cpp
+++ b/src/pigpiod/pigpiodstubs.cpp
@@ -1,4 +1,5 @@
 #include <stdexcept>
+#include <boost/predef.h>
 
 #include "pigpiod/pigpiodstubs.hpp"
 
@@ -63,6 +64,31 @@ int gpio_write(int pi, unsigned gpio, unsigned level) {
   return 0;
 }
 
+#if defined(BOOST_COMP_GNUC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#elif defined(BOOST_COMP_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+int callback_ex(int pi, unsigned user_gpio, unsigned edge, CBFuncEx_t f, void *userdata) {
+  (*pigpiodOS) << __FUNCTION__
+	       << " " << pi
+	       << " " << user_gpio
+	       << " " << edge << std::endl;
+  return 0;
+}
+#if defined(BOOST_COMP_GNUC)
+#pragma GCC diagnostic pop
+#elif defined(BOOST_COMP_CLANG)
+#pragma clang diagnostic pop
+#endif
+  
+int callback_cancel(unsigned callback_id) {
+   (*pigpiodOS) << __FUNCTION__
+		<< " " << callback_id << std::endl;
+   return 0;
+}
 
 // =============================================================================
 

--- a/src/pigpiod/pihardwaremanager.cpp
+++ b/src/pigpiod/pihardwaremanager.cpp
@@ -1,3 +1,6 @@
+#include "pigpiod/gpinputprovider.hpp"
+#include "pigpiod/gpoutputprovider.hpp"
+
 #include "pigpiod/pihardwaremanager.hpp"
 
 
@@ -14,6 +17,9 @@ namespace Lineside {
 
       auto gpOutputProvider = std::make_shared<GPOutputProvider>(this->gpioProvider);
       this->bopProviderRegistrar.Register(this->GPIO, gpOutputProvider);
+
+      auto gpInputProvider = std::make_shared<GPInputProvider>(this->gpioProvider);
+      this->bipProviderRegistrar.Register(this->GPIO, gpInputProvider);
     }
   }
 }

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -39,6 +39,7 @@ list(APPEND srcs configurationreadertests.cpp)
 list(APPEND srcs pwitemmanagertests.cpp)
 
 list(APPEND srcs pimanagertests.cpp)
+list(APPEND srcs gpiopintests.cpp)
 list(APPEND srcs gpioprovidertests.cpp)
 list(APPEND srcs gpoutputprovidertests.cpp)
 list(APPEND srcs pihardwaremanagertests.cpp)

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND srcs pimanagertests.cpp)
 list(APPEND srcs gpiopintests.cpp)
 list(APPEND srcs gpioprovidertests.cpp)
 list(APPEND srcs gpoutputprovidertests.cpp)
+list(APPEND srcs gpinputprovidertests.cpp)
 list(APPEND srcs pihardwaremanagertests.cpp)
 
 add_executable(LinesideTest ${srcs})

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -38,6 +38,7 @@ list(APPEND srcs configurationreadertests.cpp)
 
 list(APPEND srcs pwitemmanagertests.cpp)
 
+list(APPEND srcs gpiopulltests.cpp)
 list(APPEND srcs pimanagertests.cpp)
 list(APPEND srcs gpiopintests.cpp)
 list(APPEND srcs gpioprovidertests.cpp)

--- a/tst/gpinputprovidertests.cpp
+++ b/tst/gpinputprovidertests.cpp
@@ -1,0 +1,44 @@
+#include <boost/test/unit_test.hpp>
+
+#include "pigpiod/gpinputprovider.hpp"
+
+BOOST_AUTO_TEST_SUITE( GPInputProvider )
+
+BOOST_AUTO_TEST_CASE( Smoke )
+{
+  std::shared_ptr<Lineside::PiGPIOd::GPInputProvider> provider;
+  {
+    auto pm = Lineside::PiGPIOd::PiManager::CreatePiManager();
+    
+    auto gpioProvider = std::make_shared<Lineside::PiGPIOd::GPIOProvider>(pm);
+    
+    provider = std::make_shared<Lineside::PiGPIOd::GPInputProvider>(gpioProvider);
+  }
+  BOOST_REQUIRE(provider);
+}
+
+BOOST_AUTO_TEST_CASE( GetPin )
+{
+  std::shared_ptr<Lineside::PiGPIOd::GPInputProvider> provider;
+  {
+    auto pm = Lineside::PiGPIOd::PiManager::CreatePiManager();
+    
+    auto gpioProvider = std::make_shared<Lineside::PiGPIOd::GPIOProvider>(pm);
+    
+    provider = std::make_shared<Lineside::PiGPIOd::GPInputProvider>(gpioProvider);
+  }
+  BOOST_REQUIRE(provider);
+
+  std::string pinId = "5";
+  auto settings = std::map<std::string,std::string>();
+  settings["glitch"] = "90000000";
+  settings["pud"] = "Down";
+
+  auto bip = provider->GetHardware( pinId, settings );
+  BOOST_REQUIRE( bip );
+
+  // With pulldown resistor, should always be in off state
+  BOOST_CHECK_EQUAL( bip->Get(), false );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/gpinputprovidertests.cpp
+++ b/tst/gpinputprovidertests.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE( GetPin )
 
   std::string pinId = "5";
   auto settings = std::map<std::string,std::string>();
-  settings["glitch"] = "90000000";
+  settings["glitch"] = "300000";
   settings["pud"] = "Down";
 
   auto bip = provider->GetHardware( pinId, settings );

--- a/tst/gpiopintests.cpp
+++ b/tst/gpiopintests.cpp
@@ -1,0 +1,46 @@
+#include <boost/test/unit_test.hpp>
+
+#include "pigpiod/gpiopin.hpp"
+
+BOOST_AUTO_TEST_SUITE( GPIOPin )
+
+BOOST_AUTO_TEST_CASE( Smoke )
+{
+  auto pm = Lineside::PiGPIOd::PiManager::CreatePiManager();
+
+  const int pinId = 5;
+  Lineside::PiGPIOd::GPIOPin pin(pm, pinId);
+  
+  BOOST_CHECK_EQUAL( pin.getPi(), pm->getId() );
+  BOOST_CHECK_EQUAL( pin.getPin(), pinId );
+}
+
+BOOST_AUTO_TEST_CASE( CallBackInvoked )
+{
+  const unsigned char pinId = 5;
+  auto pm = Lineside::PiGPIOd::PiManager::CreatePiManager();
+
+  Lineside::PiGPIOd::GPIOPin pin(pm, pinId);
+
+  bool funcCalled = false;
+  bool level = false;
+  Lineside::PiGPIOd::GPIOPin::CallBackFn f = [&funcCalled,&level](bool l) {
+					       funcCalled = true;
+					       level = l;
+					     };
+
+  pin.SetCallBack(Lineside::PiGPIOd::GPIOEdge::Either, f);
+
+  // Invoke to true
+  pin.InvokeCallBack(pin.getPi(), pinId, 1, 0);
+  BOOST_CHECK( funcCalled );
+  BOOST_CHECK( level );
+
+  // Invoke to false
+  funcCalled = false;
+  pin.InvokeCallBack(pin.getPi(), pinId, 0, 0);
+  BOOST_CHECK( funcCalled );
+  BOOST_CHECK( !level );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/gpioprovidertests.cpp
+++ b/tst/gpioprovidertests.cpp
@@ -28,6 +28,22 @@ BOOST_AUTO_TEST_CASE( GetOneOutput )
   BOOST_CHECK_EQUAL( pin->Get(), false );
 }
 
+BOOST_AUTO_TEST_CASE( GetOneInput )
+{
+  auto pm = Lineside::PiGPIOd::PiManager::CreatePiManager();
+
+  Lineside::PiGPIOd::GPIOProvider provider(pm);
+
+  const unsigned int glitchmicrosecs = 0;
+  auto pin = provider.GetGPInput(5,
+				 Lineside::PiGPIOd::GPIOPull::Down,
+				 glitchmicrosecs,
+				 Lineside::PiGPIOd::GPIOEdge::Either);
+  
+  // With the pulldown resistor, the pin should be off even with real hardware
+  BOOST_CHECK_EQUAL( pin->Get(), false );
+}
+
 BOOST_AUTO_TEST_CASE( NoDoublePinId )
 {
   const unsigned char pinId = 5;

--- a/tst/gpiopulltests.cpp
+++ b/tst/gpiopulltests.cpp
@@ -1,0 +1,36 @@
+#include <boost/test/unit_test.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/data/monomorphic.hpp>
+
+#include <sstream>
+
+#include "pigpiod/gpiopull.hpp"
+
+char const* pullNames[] = { "Off", "Down", "Up" };
+Lineside::PiGPIOd::GPIOPull pulls[] = { Lineside::PiGPIOd::GPIOPull::Off,
+					Lineside::PiGPIOd::GPIOPull::Down,
+					Lineside::PiGPIOd::GPIOPull::Up };
+
+auto nameToPullZip = boost::unit_test::data::make(pullNames)
+  ^ boost::unit_test::data::make(pulls);
+
+BOOST_AUTO_TEST_SUITE( GPIOPull )
+
+BOOST_DATA_TEST_CASE( ToString, nameToPullZip, name, pull )
+{
+  BOOST_CHECK_EQUAL( name, Lineside::PiGPIOd::ToString(pull) );
+}
+
+BOOST_DATA_TEST_CASE( StreamInsertion, nameToPullZip, name, pull )
+{
+  std::stringstream res;
+  res << pull;
+  BOOST_CHECK_EQUAL( res.str(), name );
+}
+
+BOOST_DATA_TEST_CASE( Parse, nameToPullZip, name, pull )
+{
+  BOOST_CHECK_EQUAL( pull, Lineside::Parse<Lineside::PiGPIOd::GPIOPull>(name) );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/pihardwaremanagertests.cpp
+++ b/tst/pihardwaremanagertests.cpp
@@ -4,7 +4,7 @@
 
 BOOST_AUTO_TEST_SUITE( PiHardwareManager )
 
-BOOST_AUTO_TEST_CASE( Smoke )
+BOOST_AUTO_TEST_CASE( SmokeOutputPin )
 {
   Lineside::HardwareManagerData hmd;
 
@@ -23,6 +23,27 @@ BOOST_AUTO_TEST_CASE( Smoke )
 
   auto gpbop = dynamic_cast<Lineside::PiGPIOd::GPOutput*>(pin.get());
   BOOST_REQUIRE(gpbop);
+}
+
+BOOST_AUTO_TEST_CASE( SmokeInputPin )
+{
+  Lineside::HardwareManagerData hmd;
+  Lineside::PiGPIOd::PiHardwareManager pi(hmd);
+
+  auto bipProvider = pi.bipProviderRegistrar.Retrieve("GPIO");
+  BOOST_REQUIRE( bipProvider );
+  
+  std::string pinId = "5";
+  auto settings = std::map<std::string,std::string>();
+  settings["pud"] = "Down";
+
+  auto pin = bipProvider->GetHardware( pinId, settings );
+  BOOST_REQUIRE(pin);
+  // With the pulldown resistor, expect the pin to be off
+  BOOST_CHECK_EQUAL( pin->Get(), false );
+
+  auto gpbip = dynamic_cast<Lineside::PiGPIOd::GPInput*>(pin.get());
+  BOOST_REQUIRE(gpbip);
 }
 
 BOOST_AUTO_TEST_CASE( CheckGPIODevice )


### PR DESCRIPTION
Support the input capabilities for GPIO pins provided by pigpiod. Not all features of pigpiod are covered, though. The changes include:
- Several constants and routines added to `pigpiodstubs`
- enum classes for input pin related constants
- Ensure that input and output pins are returned via `std::unique_ptr`s and not `std::shared_ptr`s
- Define a type of `std::function` which can be used for callbacks
- Tests to cover basic functionality (necessarily limited since correctness ultimately relies on interactions with pigpiod)