### PR TITLE
Add app for testing TrackCircuitMonitor

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(signals)
+add_subdirectory(trackcircuitmonitor)

--- a/apps/trackcircuitmonitor/CMakeLists.txt
+++ b/apps/trackcircuitmonitor/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(srcs)
 
 list(APPEND srcs main.cpp)
+list(APPEND srcs stubsoftwaremanager.cpp)
 
 add_executable(TrackCircuitMonitor ${srcs})
 

--- a/apps/trackcircuitmonitor/CMakeLists.txt
+++ b/apps/trackcircuitmonitor/CMakeLists.txt
@@ -2,6 +2,7 @@ set(srcs)
 
 list(APPEND srcs main.cpp)
 list(APPEND srcs stubsoftwaremanager.cpp)
+list(APPEND srcs cmdlineopts.cpp)
 
 add_executable(TrackCircuitMonitor ${srcs})
 

--- a/apps/trackcircuitmonitor/CMakeLists.txt
+++ b/apps/trackcircuitmonitor/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(srcs)
+
+list(APPEND srcs main.cpp)
+
+add_executable(TrackCircuitMonitor ${srcs})
+
+target_include_directories(TrackCircuitMonitor
+  SYSTEM PRIVATE ${Boost_INCLUDE_DIRS})
+
+# Note that linking against the lineside library will
+# automatically include the corresponding headers in
+# the compile commands
+target_link_libraries(TrackCircuitMonitor lineside ${Boost_LIBRARIES})
+
+configure_file(track-circuits.xml . COPYONLY)

--- a/apps/trackcircuitmonitor/cmdlineopts.cpp
+++ b/apps/trackcircuitmonitor/cmdlineopts.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <boost/program_options.hpp>
+
+#include "cmdlineopts.hpp"
+
+namespace bpo = boost::program_options;
+
+void CmdLineOpts::Populate(int argc, char* argv[]) {
+  const std::string configOpt = "configuration-file";
+  const char configOptSingle = 'f';
+  const std::string configOptDesc = "Path to configuration XML file";
+  
+  const std::string configOptSpec = configOpt + "," + configOptSingle;
+  
+  bpo::options_description desc("Allowed Options");
+  desc.add_options()
+    ("help", "Show help message")
+    (configOptSpec.c_str(), bpo::value<std::string>(&(this->configFilePath)), configOptDesc.c_str())
+    ;
+  
+  bpo::variables_map vm;
+  bpo::store(bpo::parse_command_line(argc, argv, desc), vm);
+  bpo::notify(vm);
+  
+  if( vm.count("help") ) {
+    std::cout << desc << std::endl;
+    this->helpMessagePrinted = true;
+    return;
+  }
+  
+  if( vm.count(configOpt.c_str()) ) {
+    std::cout << "Configuration file: " << this->configFilePath << std::endl;
+  } else {
+    throw std::runtime_error("Configuration file not specified");
+  }
+  
+}

--- a/apps/trackcircuitmonitor/cmdlineopts.hpp
+++ b/apps/trackcircuitmonitor/cmdlineopts.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+class CmdLineOpts {
+public:
+  CmdLineOpts() :
+    helpMessagePrinted(false),
+    configFilePath() {}
+
+  bool helpMessagePrinted;
+  std::string configFilePath;
+
+  void Populate(int argc, char* argv[]);
+};

--- a/apps/trackcircuitmonitor/main.cpp
+++ b/apps/trackcircuitmonitor/main.cpp
@@ -1,0 +1,5 @@
+#include <iostream>
+
+int main() {
+  return EXIT_SUCCESS;
+}

--- a/apps/trackcircuitmonitor/main.cpp
+++ b/apps/trackcircuitmonitor/main.cpp
@@ -1,5 +1,57 @@
 #include <iostream>
+#include "pigpiod/pihardwaremanager.hpp"
+#include "xml/configurationreader.hpp"
+#include "trackcircuitmonitordata.hpp"
 
-int main() {
+#include "pwitemmanager.hpp"
+
+#include "cmdlineopts.hpp"
+#include "stubsoftwaremanager.hpp"
+
+void CheckPWItems(const std::vector<std::shared_ptr<Lineside::PWItemData>>& pwItems) {
+  for( auto it=pwItems.begin(); it!=pwItems.end(); ++it ) {
+    auto signal = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitorData>(*it);
+    if( !signal ) {
+      throw std::runtime_error("All PWItems must be of type TrackCircuitMonitor");
+    }
+  }
+}
+
+int main(int argc, char* argv[]) {
+  try {
+    CmdLineOpts opts;
+    opts.Populate(argc, argv);
+    if( opts.helpMessagePrinted ) {
+      return EXIT_SUCCESS;
+    }
+
+    Lineside::xml::ConfigurationReader cr;
+
+    auto config = cr.Read(opts.configFilePath);
+    CheckPWItems(config.pwItems);
+
+    auto hw = std::make_shared<Lineside::PiGPIOd::PiHardwareManager>(config.hwManager);
+    auto sw = std::make_shared<StubSoftwareManager>();
+    Lineside::PWItemManager pwItemManager( hw, sw );
+
+    pwItemManager.CreatePWItems(config.pwItems);
+
+    std::cout << "Entering main loop" << std::endl;
+    std::cout << "Type q to quit" << std::endl;
+    bool done = false;
+    while( !done ) {
+      std::string inputLine;
+      std::getline( std::cin, inputLine );
+      if( inputLine == "q" ) {
+	std::cout << "Received quit" << std::endl;
+	done = true;
+      }
+    }
+  }
+  catch(std::exception& e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  
   return EXIT_SUCCESS;
 }

--- a/apps/trackcircuitmonitor/stubsoftwaremanager.cpp
+++ b/apps/trackcircuitmonitor/stubsoftwaremanager.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+
+#include "stubsoftwaremanager.hpp"
+
+void StubRTCClient::SendTrackCircuitNotification(const Lineside::ItemId trackCircuitId,
+						 const bool occupied ) {
+  std::cout << __FUNCTION__ << ": "
+	    << trackCircuitId << " "
+	    << occupied << std::endl;
+}
+
+std::shared_ptr<Lineside::RTCClient> StubSoftwareManager::GetRTCClient() {
+  auto result = std::make_shared<StubRTCClient>();
+
+  this->rtcClientList.push_back(result);
+
+  return result;
+}

--- a/apps/trackcircuitmonitor/stubsoftwaremanager.hpp
+++ b/apps/trackcircuitmonitor/stubsoftwaremanager.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "rtcclient.hpp"
+#include "softwaremanager.hpp"
+
+class StubRTCClient : public Lineside::RTCClient {
+public:
+  StubRTCClient() : RTCClient() {}
+  
+  virtual void SendTrackCircuitNotification(const Lineside::ItemId trackCircuitId,
+					    const bool occupied ) override;
+};
+
+class StubSoftwareManager : public Lineside::SoftwareManager {
+public:
+  StubSoftwareManager() :
+    SoftwareManager(),
+    rtcClientList() {}
+  
+  virtual std::shared_ptr<Lineside::RTCClient> GetRTCClient() override;
+  
+  std::vector<std::shared_ptr<StubRTCClient>> rtcClientList;
+};

--- a/apps/trackcircuitmonitor/track-circuits.xml
+++ b/apps/trackcircuitmonitor/track-circuits.xml
@@ -15,6 +15,7 @@
       <BinaryInput controller="GPIO" controllerData="17">
 	<Settings>
           <Setting key="glitch" value="300000" />
+	  <Setting key="pud" value="Down" />
 	</Settings>
       </BinaryInput>
     </TrackCircuitMonitor>
@@ -23,6 +24,7 @@
       <BinaryInput controller="GPIO" controllerData="22">
 	<Settings>
           <Setting key="glitch" value="300000" />
+	  <Setting key="pud" value="Down" />
 	</Settings>
       </BinaryInput>
     </TrackCircuitMonitor>

--- a/apps/trackcircuitmonitor/track-circuits.xml
+++ b/apps/trackcircuitmonitor/track-circuits.xml
@@ -10,7 +10,6 @@
     <I2CDevices />
     <Settings />
   </HardwareManager>
-  <!-- ---------------------- -->
   <PermanentWayItems>
     <TrackCircuitMonitor id="00:ff:00:aa">
       <BinaryInput controller="GPIO" controllerData="17">

--- a/apps/trackcircuitmonitor/track-circuits.xml
+++ b/apps/trackcircuitmonitor/track-circuits.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<LinesideCabinet>
+  <SoftwareManager>
+    <RTC address="addr" port="8081" />
+    <Settings>
+      <Setting key="aKey" value="bValue" />
+    </Settings>
+  </SoftwareManager>
+  <HardwareManager>
+    <I2CDevices />
+    <Settings />
+  </HardwareManager>
+  <!-- ---------------------- -->
+  <PermanentWayItems>
+    <TrackCircuitMonitor id="00:ff:00:aa">
+      <BinaryInput controller="GPIO" controllerData="17">
+	<Settings>
+          <Setting key="glitch" value="300000" />
+	</Settings>
+      </BinaryInput>
+    </TrackCircuitMonitor>
+    <!-- -------- -->
+    <TrackCircuitMonitor id="00:ff:00:aa">
+      <BinaryInput controller="GPIO" controllerData="22">
+	<Settings>
+          <Setting key="glitch" value="300000" />
+	</Settings>
+      </BinaryInput>
+    </TrackCircuitMonitor>
+  </PermanentWayItems>
+</LinesideCabinet>


### PR DESCRIPTION
A simple application which enables testing of the `TrackCircuitMonitor` class and associated input pin paraphernalia. This has uncovered two issues in the XML reader, opened as issues #38 and #39 .

While this has shown that the callbacks etc. are working, consideration of how often to send notifications is required.