### PR TITLE
Extra tests for XML readers

### DIFF
--- a/apps/trackcircuitmonitor/track-circuits.xml
+++ b/apps/trackcircuitmonitor/track-circuits.xml
@@ -10,6 +10,7 @@
     <I2CDevices />
     <Settings />
   </HardwareManager>
+  <!-- Start of the item list -->
   <PermanentWayItems>
     <TrackCircuitMonitor id="00:ff:00:aa">
       <BinaryInput controller="GPIO" controllerData="17">
@@ -19,8 +20,8 @@
 	</Settings>
       </BinaryInput>
     </TrackCircuitMonitor>
-    <!-- -------- -->
-    <TrackCircuitMonitor id="00:ff:00:aa">
+    <!-- Comment -->
+    <TrackCircuitMonitor id="ff:00:00:11">
       <BinaryInput controller="GPIO" controllerData="22">
 	<Settings>
           <Setting key="glitch" value="300000" />

--- a/tst/configurationreadertests.cpp
+++ b/tst/configurationreadertests.cpp
@@ -9,6 +9,7 @@
 // ==============
 
 const std::string configurationFile = "full-configuration-sample.xml";
+const std::string configFileTwoTCM = "full-configuration-two-tcm.xml";
 
 // ==============
 
@@ -26,7 +27,7 @@ BOOST_AUTO_TEST_CASE( SmokeReader )
   BOOST_CHECK_EQUAL( res.swManager.rtcAddress, "addr" );
   BOOST_CHECK_EQUAL( res.swManager.rtcPort, 8081 );
   BOOST_REQUIRE_EQUAL( res.swManager.settings.size(), 1 );
-  BOOST_CHECK_EQUAL( res.swManager.settings.at("aKey"), "bValue" );
+  BOOST_CHECK_EQUAL( res.swManager.settings.at("aKey"), "cValue" );
 
   // Check the hardware manager
   BOOST_REQUIRE_EQUAL( res.hwManager.i2cDevices.size(), 1 );
@@ -51,6 +52,34 @@ BOOST_AUTO_TEST_CASE( SmokeReader )
   BOOST_CHECK_EQUAL( tcmd0->inputPinRequest.controllerData, "07" );
   BOOST_REQUIRE_EQUAL( tcmd0->inputPinRequest.settings.size(), 1 );
   BOOST_CHECK_EQUAL( tcmd0->inputPinRequest.settings.at("glitch"), "20000" );
+}
+
+BOOST_AUTO_TEST_CASE( ReadTwoTCM )
+{
+  Lineside::xml::ConfigurationReader reader;
+
+  auto fullPath = GetPathToSampleXML( configFileTwoTCM );
+  
+  auto res = reader.Read( fullPath );
+
+  // Check the software manager
+  BOOST_CHECK_EQUAL( res.swManager.rtcAddress, "addr" );
+  BOOST_CHECK_EQUAL( res.swManager.rtcPort, 8082 );
+  BOOST_REQUIRE_EQUAL( res.swManager.settings.size(), 1 );
+  BOOST_CHECK_EQUAL( res.swManager.settings.at("aKey"), "bValue" );
+
+  // Check the hardware manager
+  BOOST_REQUIRE_EQUAL( res.hwManager.i2cDevices.size(), 0 );
+
+  BOOST_REQUIRE_EQUAL( res.hwManager.settings.size(), 1 );
+  BOOST_CHECK_EQUAL( res.hwManager.settings.at("hwA"), "hwB" );
+
+  // Check the list of PWItems
+  BOOST_REQUIRE_EQUAL( res.pwItems.size(), 2 );
+  for( size_t i=0; i<2; ++i ) {
+    auto tcmd = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitorData>(res.pwItems.at(i));
+    BOOST_REQUIRE( tcmd );
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/configurationreadertests.cpp
+++ b/tst/configurationreadertests.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE( SmokeReader )
   BOOST_CHECK_EQUAL( res.swManager.rtcAddress, "addr" );
   BOOST_CHECK_EQUAL( res.swManager.rtcPort, 8081 );
   BOOST_REQUIRE_EQUAL( res.swManager.settings.size(), 1 );
-  BOOST_CHECK_EQUAL( res.swManager.settings.at("aKey"), "cValue" );
+  BOOST_CHECK_EQUAL( res.swManager.settings.at("aKey"), "bValue" );
 
   // Check the hardware manager
   BOOST_REQUIRE_EQUAL( res.hwManager.i2cDevices.size(), 1 );
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE( ReadTwoTCM )
   BOOST_CHECK_EQUAL( res.swManager.rtcAddress, "addr" );
   BOOST_CHECK_EQUAL( res.swManager.rtcPort, 8082 );
   BOOST_REQUIRE_EQUAL( res.swManager.settings.size(), 1 );
-  BOOST_CHECK_EQUAL( res.swManager.settings.at("aKey"), "bValue" );
+  BOOST_CHECK_EQUAL( res.swManager.settings.at("aKey"), "cValue" );
 
   // Check the hardware manager
   BOOST_REQUIRE_EQUAL( res.hwManager.i2cDevices.size(), 0 );
@@ -75,10 +75,14 @@ BOOST_AUTO_TEST_CASE( ReadTwoTCM )
   BOOST_CHECK_EQUAL( res.hwManager.settings.at("hwA"), "hwB" );
 
   // Check the list of PWItems
+  Lineside::ItemId expectedId;
+  expectedId.Parse("00:ff:00:aa");
   BOOST_REQUIRE_EQUAL( res.pwItems.size(), 2 );
   for( size_t i=0; i<2; ++i ) {
     auto tcmd = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitorData>(res.pwItems.at(i));
     BOOST_REQUIRE( tcmd );
+    // All items share the same id. This is permitted when reading in the configuration
+    BOOST_CHECK_EQUAL( expectedId, tcmd->id );
   }
 }
 

--- a/tst/pwitemlistreadertests.cpp
+++ b/tst/pwitemlistreadertests.cpp
@@ -18,6 +18,7 @@
 // ====================
 
 const std::string pwitemlistFragment = "pwitemlist.xml";
+const std::string pwitemlistTwoTCMFragment = "pwitemlist-two-tcm.xml";
 
 // ====================
 
@@ -55,6 +56,34 @@ BOOST_AUTO_TEST_CASE( SmokePWItemListReader )
   Lineside::ItemId stmId;
   stmId.Parse("00:0e:2a:5f");
   BOOST_CHECK_EQUAL( stmd->id, stmId );
+}
+
+BOOST_AUTO_TEST_CASE( TwoTrackCircuitMonitors )
+{
+  Lineside::xml::XercesGuard xg;
+  auto parser = GetParser();
+
+  auto rootElement = GetRootElementOfFile(parser, pwitemlistTwoTCMFragment);
+  BOOST_REQUIRE(rootElement);
+
+  Lineside::xml::PWItemListReader reader;
+  auto listElement = reader.GetPWItemListElement(rootElement);
+  BOOST_REQUIRE(listElement);
+
+  std::vector<std::shared_ptr<Lineside::PWItemData>> pwItems = reader.Read(listElement);
+  BOOST_REQUIRE_EQUAL( pwItems.size(), 2 );
+
+  std::vector<Lineside::ItemId> expectedIds;
+  Lineside::ItemId id;
+  id.Parse("00:fe:00:1a");
+  expectedIds.push_back(id);
+  id.Parse("00:fe:00:00");
+  expectedIds.push_back(id);
+  for( size_t i=0; i<pwItems.size(); i++ ) {
+    auto tcmd = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitorData>(pwItems.at(i));
+    BOOST_REQUIRE( tcmd );
+    BOOST_CHECK_EQUAL( tcmd->id, expectedIds.at(i) );
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/xmlsamples/CMakeLists.txt
+++ b/tst/xmlsamples/CMakeLists.txt
@@ -19,3 +19,4 @@ configure_file(i2cdevicelist-fragment.xml . COPYONLY)
 configure_file(hardwaremanager-fragment.xml . COPYONLY)
 
 configure_file(full-configuration-sample.xml . COPYONLY)
+configure_file(full-configuration-two-tcm.xml . COPYONLY)

--- a/tst/xmlsamples/CMakeLists.txt
+++ b/tst/xmlsamples/CMakeLists.txt
@@ -10,6 +10,7 @@ configure_file(pwitem-trackcircuitmonitor.xml . COPYONLY)
 configure_file(pwitem-multiaspectsignalhead.xml . COPYONLY)
 
 configure_file(pwitemlist.xml . COPYONLY)
+configure_file(pwitemlist-two-tcm.xml . COPYONLY)
 
 configure_file(softwaremanagerdata-fragment.xml . COPYONLY)
 

--- a/tst/xmlsamples/full-configuration-two-tcm.xml
+++ b/tst/xmlsamples/full-configuration-two-tcm.xml
@@ -12,6 +12,7 @@
       <Setting key="hwA" value="hwB" />
     </Settings>
   </HardwareManager>
+  <!-- Start of the Permanent Way Items -->
   <PermanentWayItems>
     <TrackCircuitMonitor id="00:ff:00:aa">
       <BinaryInput controller="GPIO" controllerData="17">
@@ -20,7 +21,7 @@
 	</Settings>
       </BinaryInput>
     </TrackCircuitMonitor>
-    <!-- -------- -->
+    <!-- Comment -->
     <TrackCircuitMonitor id="00:ff:00:aa">
       <BinaryInput controller="GPIO" controllerData="22">
 	<Settings>

--- a/tst/xmlsamples/full-configuration-two-tcm.xml
+++ b/tst/xmlsamples/full-configuration-two-tcm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<LinesideCabinet>
+  <SoftwareManager>
+    <RTC address="addr" port="8082" />
+    <Settings>
+      <Setting key="aKey" value="cValue" />
+    </Settings>
+  </SoftwareManager>
+  <HardwareManager>
+    <I2CDevices />
+    <Settings>
+      <Setting key="hwA" value="hwB" />
+    </Settings>
+  </HardwareManager>
+  <PermanentWayItems>
+    <TrackCircuitMonitor id="00:ff:00:aa">
+      <BinaryInput controller="GPIO" controllerData="17">
+	<Settings>
+          <Setting key="glitch" value="300000" />
+	</Settings>
+      </BinaryInput>
+    </TrackCircuitMonitor>
+    <!-- -------- -->
+    <TrackCircuitMonitor id="00:ff:00:aa">
+      <BinaryInput controller="GPIO" controllerData="22">
+	<Settings>
+          <Setting key="glitch" value="300000" />
+	</Settings>
+      </BinaryInput>
+    </TrackCircuitMonitor>
+  </PermanentWayItems>
+</LinesideCabinet>

--- a/tst/xmlsamples/pwitemlist-two-tcm.xml
+++ b/tst/xmlsamples/pwitemlist-two-tcm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Test>
+  <!-- Start with a comment -->
+  <PermanentWayItems>
+    <!-- Here begins the list -->
+    <TrackCircuitMonitor id="00:fe:00:1a">
+      <!-- A single input pin -->
+      <BinaryInput controller="GPIO" controllerData="07">
+	<Settings>
+	  <!-- The pin has a setting with it -->
+	  <Setting key="glitch" value="10000" />
+	</Settings>
+      </BinaryInput>
+    </TrackCircuitMonitor>
+    <!-- And the next TCM -->
+    <TrackCircuitMonitor id="00:fe:00:00">
+      <!-- A single input pin -->
+      <BinaryInput controller="GPIO" controllerData="08">
+	<Settings>
+	  <!-- The pin has a setting with it -->
+	  <Setting key="glitch" value="10000" />
+	</Settings>
+      </BinaryInput>
+    </TrackCircuitMonitor>
+  </PermanentWayItems>
+</Test>


### PR DESCRIPTION
Some extra tests for the XML readers. These were prompted by #38 and #39 . However, it seems that these were actually due to problems in the XML files - [XML comments may not contain `--` strings](https://www.w3.org/TR/REC-xml/#sec-comments). Having the extra tests will not hurt, though.

Closes #38 and #39 