### PR TITLE
Allow longer wakeups for PWItemModels

### DIFF
--- a/include/pwitemcontroller.hpp
+++ b/include/pwitemcontroller.hpp
@@ -40,7 +40,7 @@ namespace Lineside {
     
   private:
     enum class ControllerState { Constructed, Active, Inactive };
-    const std::chrono::seconds MaximumWaitSeconds = std::chrono::seconds(5);
+    const std::chrono::seconds MaximumWaitSeconds = std::chrono::seconds(120);
     
     std::shared_ptr<PWItemModel> model;
     ItemId id;

--- a/include/trackcircuitmonitor.hpp
+++ b/include/trackcircuitmonitor.hpp
@@ -14,7 +14,7 @@ namespace Lineside {
   //! Class to monitor a track circuit and send notifications to rail traffic control
   class TrackCircuitMonitor : public PWItemModel, public Notifiable<bool> {
   public:
-    const std::chrono::milliseconds SleepRequest = std::chrono::milliseconds(5000);
+    const std::chrono::milliseconds SleepRequest = std::chrono::seconds(60);
     
     virtual void OnActivate() override;
 

--- a/tst/pwitemcontrollertests.cpp
+++ b/tst/pwitemcontrollertests.cpp
@@ -71,7 +71,8 @@ void PauseForThread() {
 
 // ===================================
 
-BOOST_AUTO_TEST_SUITE(PWItemController)
+BOOST_AUTO_TEST_SUITE(PWItemController,
+		      *boost::unit_test::description("Tests of the PWItemController"))
 
 BOOST_AUTO_TEST_CASE(BasicLifeCycle, *boost::unit_test::timeout(2))
 {
@@ -130,7 +131,9 @@ BOOST_AUTO_TEST_CASE(ShortDurationSleeps, *boost::unit_test::timeout(2))
   }
 }
 
-BOOST_AUTO_TEST_CASE(LongSleepIgnored, *boost::unit_test::timeout(30))
+BOOST_AUTO_TEST_CASE(LongSleepIgnored,
+		     *boost::unit_test::timeout(600)
+		     *boost::unit_test::label("LongRunning"))
 {
   Lineside::ItemId id = Lineside::ItemId::Random();
   auto model = std::make_shared<MockModel>(id);
@@ -138,13 +141,13 @@ BOOST_AUTO_TEST_CASE(LongSleepIgnored, *boost::unit_test::timeout(30))
   BOOST_CHECK_EQUAL(model->onRunCallTimes.size(), 0);
 
   // Set too long sleep request
-  model->onRunWait = std::chrono::seconds(20);
+  model->onRunWait = std::chrono::seconds(550);
 
   controller->Activate();
-  std::this_thread::sleep_for(std::chrono::seconds(25));
+  std::this_thread::sleep_for(std::chrono::seconds(400));
 
-  // Should get at least four OnRun() calls due to MaximumWaitTime
-  BOOST_CHECK_GE( model->onRunCallTimes.size(), 4 );
+  // Should get at least three OnRun() calls due to MaximumWaitTime
+  BOOST_CHECK_GE( model->onRunCallTimes.size(), 3 );
   
 }
 

--- a/tst/trackcircuitmonitortests.cpp
+++ b/tst/trackcircuitmonitortests.cpp
@@ -94,6 +94,7 @@ BOOST_AUTO_TEST_CASE(OnRunSendsToRTC)
   const Lineside::ItemId id(10);
   const std::string controller = "BIP";
   const std::string controllerData = "07";
+  const std::chrono::seconds expectedSleepRequest = std::chrono::seconds(60);
 
   Lineside::TrackCircuitMonitorData tcmd;
   tcmd.id = id;
@@ -121,7 +122,7 @@ BOOST_AUTO_TEST_CASE(OnRunSendsToRTC)
 
   // Have TCM send unconditionally
   auto sleepTime = pwItem->OnRun();
-  BOOST_CHECK( sleepTime == std::chrono::milliseconds(5000) );
+  BOOST_CHECK( sleepTime == expectedSleepRequest );
   BOOST_CHECK_EQUAL( mockRTC->lastItemId, id );
   BOOST_CHECK_EQUAL( mockRTC->lastOccupied, false );
   mockRTC->lastItemId = Lineside::ItemId(0);
@@ -135,7 +136,7 @@ BOOST_AUTO_TEST_CASE(OnRunSendsToRTC)
 
   // Send again, will no longer have state change
   sleepTime = pwItem->OnRun();
-  BOOST_CHECK( sleepTime == std::chrono::milliseconds(5000) );
+  BOOST_CHECK( sleepTime == expectedSleepRequest );
   BOOST_CHECK_EQUAL( mockRTC->lastItemId, id );
   BOOST_CHECK_EQUAL( mockRTC->lastOccupied, true );
   BOOST_CHECK_EQUAL( pwItem->HaveStateChange(), false );
@@ -148,7 +149,7 @@ BOOST_AUTO_TEST_CASE(OnRunSendsToRTC)
   
   // Send again, will no longer have state change
   sleepTime = pwItem->OnRun();
-  BOOST_CHECK( sleepTime == std::chrono::milliseconds(5000) );
+  BOOST_CHECK( sleepTime == expectedSleepRequest );
   BOOST_CHECK_EQUAL( mockRTC->lastItemId, id );
   BOOST_CHECK_EQUAL( mockRTC->lastOccupied, false );
   BOOST_CHECK_EQUAL( pwItem->HaveStateChange(), false );


### PR DESCRIPTION
Increase the maximum allowed wake up time which may be requested by `PWItemModel` instances. This is mainly for `TrackCircuitMonitor` so that it won't send so many extra updates to rail traffic control.

Unfortunately, this does slow down the test suite a lot, since there is a test which ensures that this limit is applied. At the moment, Boost.Test doesn't appear to support _excluding_ a label from a test run.