### PR TITLE
Update use of Boost in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake_modules" ${CMAKE_MODULE_PATH}
 find_package(Threads REQUIRED)
 
 find_package(Boost REQUIRED
-  COMPONENTS filesystem system program_options unit_test_framework)
+  COMPONENTS filesystem program_options unit_test_framework)
 
 find_package(Doxygen)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake_modules" ${CMAKE_MODULE_PATH}
 
 find_package(Threads REQUIRED)
 
-find_package(Boost REQUIRED COMPONENTS filesystem system program_options)
+find_package(Boost REQUIRED
+  COMPONENTS filesystem system program_options unit_test_framework)
 
 find_package(Doxygen)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake_modules" ${CMAKE_MODULE_PATH}
 find_package(Threads REQUIRED)
 
 find_package(Boost REQUIRED
-  COMPONENTS filesystem program_options unit_test_framework)
+  COMPONENTS filesystem program_options)
 
 find_package(Doxygen)
 

--- a/apps/signals/CMakeLists.txt
+++ b/apps/signals/CMakeLists.txt
@@ -7,12 +7,9 @@ list(APPEND srcs runonconsole.cpp)
 
 add_executable(Signals ${srcs})
 
-target_include_directories(Signals
-  SYSTEM PRIVATE ${Boost_INCLUDE_DIRS})
-
 # Note that linking against the lineside library will
 # automatically include the corresponding headers in
 # the compile commands
-target_link_libraries(Signals lineside ${Boost_LIBRARIES})
+target_link_libraries(Signals PUBLIC lineside Boost::program_options)
 
 configure_file(single-signal.xml . COPYONLY)

--- a/apps/trackcircuitmonitor/CMakeLists.txt
+++ b/apps/trackcircuitmonitor/CMakeLists.txt
@@ -6,12 +6,9 @@ list(APPEND srcs cmdlineopts.cpp)
 
 add_executable(TrackCircuitMonitor ${srcs})
 
-target_include_directories(TrackCircuitMonitor
-  SYSTEM PRIVATE ${Boost_INCLUDE_DIRS})
-
 # Note that linking against the lineside library will
 # automatically include the corresponding headers in
 # the compile commands
-target_link_libraries(TrackCircuitMonitor lineside ${Boost_LIBRARIES})
+target_link_libraries(TrackCircuitMonitor PUBLIC lineside Boost::program_options)
 
 configure_file(track-circuits.xml . COPYONLY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,9 +26,9 @@ list(APPEND srcs pwitemmanager.cpp)
 add_library(lineside ${srcs})
 target_include_directories(lineside
   PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_include_directories(lineside SYSTEM
-  PRIVATE ${Boost_INCLUDE_DIRS})
-target_link_libraries(lineside PUBLIC Threads::Threads)
+target_link_libraries(lineside
+  PUBLIC Threads::Threads
+  PRIVATE Boost::boost)
 
 add_subdirectory(xml)
 add_subdirectory(pigpiod)

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -31,7 +31,7 @@ add_executable(LinesideTest ${srcs})
 # The following is so that subdirectories can find things like
 # exceptionmessagecheck.hpp
 target_include_directories(LinesideTest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(LinesideTest PUBLIC lineside Boost::unit_test_framework)
+target_link_libraries(LinesideTest PUBLIC lineside Boost::boost)
 
 add_test(NAME Quick COMMAND LinesideTest --run_test=\!@LongRunning)
 

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -28,12 +28,10 @@ list(APPEND srcs pwitemmanagertests.cpp)
 
 
 add_executable(LinesideTest ${srcs})
-target_include_directories(LinesideTest
-  SYSTEM PRIVATE ${Boost_INCLUDE_DIRS})
 # The following is so that subdirectories can find things like
 # exceptionmessagecheck.hpp
 target_include_directories(LinesideTest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(LinesideTest lineside ${Boost_LIBRARIES})
+target_link_libraries(LinesideTest PUBLIC lineside Boost::unit_test_framework)
 
 add_test(NAME Quick COMMAND LinesideTest --run_test=\!@LongRunning)
 

--- a/tst/xml/CMakeLists.txt
+++ b/tst/xml/CMakeLists.txt
@@ -14,3 +14,4 @@ list(APPEND srcs softwaremanagerdatareadertests.cpp)
 list(APPEND srcs xercesguardtests.cpp)
 
 target_sources(LinesideTest PRIVATE ${srcs})
+target_link_libraries(LinesideTest PUBLIC Boost::filesystem)


### PR DESCRIPTION
Recent versions of Boost and CMake have improved integration between the two. Switch to using the new way of referencing Boost.