### PR TITLE
Add I2CDevice to libpigpiodpp

### DIFF
--- a/libpigpiodpp/include/pigpiodpp/i2cdevice.hpp
+++ b/libpigpiodpp/include/pigpiodpp/i2cdevice.hpp
@@ -28,6 +28,10 @@ namespace PiGPIOdpp {
       return this->handle;
     }
 
+    void WriteByte(uint8_t targetRegister, uint8_t value);
+
+    void WriteWord(uint8_t targetRegister, uint16_t value);
+
   private:
     std::shared_ptr<PiManager> pi;
     const unsigned int i2cBus;

--- a/libpigpiodpp/include/pigpiodpp/i2cdevice.hpp
+++ b/libpigpiodpp/include/pigpiodpp/i2cdevice.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "pigpiodpp/pimanager.hpp"
+
+namespace PiGPIOdpp {
+  //! Class for accessing an I2C device
+  class I2CDevice {
+  public:
+    I2CDevice(const std::shared_ptr<PiManager> owner,
+	      const unsigned int i2cBusId,
+	      const unsigned int i2cBusAddress);
+    
+    ~I2CDevice();
+
+    int getPi() const {
+      return this->pi->getId();
+    }
+
+    unsigned int getI2CBus() const {
+      return this->i2cBus;
+    }
+
+    unsigned int getI2CAddress() const {
+      return this->i2cAddress;
+    }
+
+    int getHandle() const {
+      return this->handle;
+    }
+
+  private:
+    std::shared_ptr<PiManager> pi;
+    const unsigned int i2cBus;
+    const unsigned int i2cAddress;
+    int handle;
+  };
+}

--- a/libpigpiodpp/include/pigpiodpp/pigpiodppexception.hpp
+++ b/libpigpiodpp/include/pigpiodpp/pigpiodppexception.hpp
@@ -10,11 +10,11 @@
 #endif
 
 namespace PiGPIOdpp {
-  //! Class for exceptions from the PiGPIOd library
-  class PiGPIOdException : public std::runtime_error {
+  //! Class for exceptions from the PiGPIOdpp library
+  class PiGPIOdppException : public std::runtime_error {
   public:
-    explicit PiGPIOdException( const std::string calledMethod,
-			       const int returnCode ) :
+    explicit PiGPIOdppException( const std::string calledMethod,
+				 const int returnCode ) :
       std::runtime_error(""),
       methodName(calledMethod),
       errorCode(returnCode),
@@ -23,13 +23,13 @@ namespace PiGPIOdpp {
       tmp << "Error from pigpiod on calling '" << this->methodName << "'. ";
       tmp << "Error code is '" << this->errorCode << "' ";
       tmp << "with explanation: " << pigpio_error(this->errorCode);
-	this->message = tmp.str();
+      this->message = tmp.str();
     }
     
     const std::string methodName;
     const int errorCode;
     std::string message;
-      
+    
     virtual const char* what() const noexcept override {
       return this->message.c_str();
     }

--- a/libpigpiodpp/include/pigpiodpp/pigpiodstubs.hpp
+++ b/libpigpiodpp/include/pigpiodpp/pigpiodstubs.hpp
@@ -71,6 +71,10 @@ extern "C" {
   int callback_cancel(unsigned callback_id);
   
   // ===================================================
+
+  int i2c_open(int pi, unsigned i2c_bus, unsigned i2c_addr, unsigned i2c_flags);
+  
+  // ===================================================
   
   char *pigpio_error(int errnum);
 #ifdef __cplusplus

--- a/libpigpiodpp/include/pigpiodpp/pigpiodstubs.hpp
+++ b/libpigpiodpp/include/pigpiodpp/pigpiodstubs.hpp
@@ -75,7 +75,11 @@ extern "C" {
   int i2c_open(int pi, unsigned i2c_bus, unsigned i2c_addr, unsigned i2c_flags);
 
   int i2c_close(int pi, unsigned handle);
+
+  int i2c_write_byte_data(int pi, unsigned handle, unsigned i2c_reg, unsigned bVal);
   
+  int i2c_write_word_data(int pi, unsigned handle, unsigned i2c_reg, unsigned wVal);
+
   // ===================================================
   
   char *pigpio_error(int errnum);

--- a/libpigpiodpp/include/pigpiodpp/pigpiodstubs.hpp
+++ b/libpigpiodpp/include/pigpiodpp/pigpiodstubs.hpp
@@ -73,6 +73,8 @@ extern "C" {
   // ===================================================
 
   int i2c_open(int pi, unsigned i2c_bus, unsigned i2c_addr, unsigned i2c_flags);
+
+  int i2c_close(int pi, unsigned handle);
   
   // ===================================================
   

--- a/libpigpiodpp/src/CMakeLists.txt
+++ b/libpigpiodpp/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(srcs)
 list(APPEND srcs gpiopull.cpp)
 list(APPEND srcs gpiopin.cpp)
 list(APPEND srcs pimanager.cpp)
+list(APPEND srcs i2cdevice.cpp)
 
 # Have to do different things if we find the C pigpiod library
 if( pigpio_FOUND )

--- a/libpigpiodpp/src/gpiopin.cpp
+++ b/libpigpiodpp/src/gpiopin.cpp
@@ -7,7 +7,7 @@
 #include "pigpiodpp/pigpiodstubs.hpp"
 #endif
 
-#include "pigpiodpp/pigpiodexceptions.hpp"
+#include "pigpiodpp/pigpiodppexception.hpp"
 
 #include "pigpiodpp/gpiopin.hpp"
 
@@ -53,7 +53,7 @@ namespace PiGPIOdpp {
 				 this->pin,
 				 static_cast<unsigned>(mode));
     if( libraryResult != 0 ) {
-      throw PiGPIOdException("set_mode", libraryResult);
+      throw PiGPIOdppException("set_mode", libraryResult);
     }
   }
   
@@ -61,7 +61,7 @@ namespace PiGPIOdpp {
     int libraryResult = gpio_read(this->pi->getId(),
 				  this->pin);
     if( libraryResult == PI_BAD_GPIO ) {
-      throw PiGPIOdException("gpio_read", libraryResult);
+      throw PiGPIOdppException("gpio_read", libraryResult);
     }
     
     return static_cast<bool>(libraryResult);
@@ -72,7 +72,7 @@ namespace PiGPIOdpp {
 				   this->pin,
 				   static_cast<unsigned>(level));
     if( libraryResult != 0 ) {
-      throw PiGPIOdException("gpio_write", libraryResult);
+      throw PiGPIOdppException("gpio_write", libraryResult);
     }
   }
   
@@ -81,7 +81,7 @@ namespace PiGPIOdpp {
 					 this->pin,
 					   static_cast<unsigned>(pull));
     if( libraryResult != 0 ) {
-      throw PiGPIOdException("set_pull_up_down", libraryResult);
+      throw PiGPIOdppException("set_pull_up_down", libraryResult);
     }    
   }
   
@@ -90,7 +90,7 @@ namespace PiGPIOdpp {
 					  this->pin,
 					  steadyMicroseconds);
     if( libraryResult != 0 ) {
-      throw PiGPIOdException("set_glitch_filter", libraryResult);
+      throw PiGPIOdppException("set_glitch_filter", libraryResult);
     } 
   }
   
@@ -103,7 +103,7 @@ namespace PiGPIOdpp {
 				    &CallBackTrampoline,
 				    this);
     if( libraryResult < 0 ) {
-      throw PiGPIOdException("callback_ex", libraryResult);
+      throw PiGPIOdppException("callback_ex", libraryResult);
     }
     this->callBackId = libraryResult;
   }

--- a/libpigpiodpp/src/i2cdevice.cpp
+++ b/libpigpiodpp/src/i2cdevice.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #ifdef PIGPIODPP_HAVE_PIGPIO
 #include <pigpiod_if2.h>
 #else

--- a/libpigpiodpp/src/i2cdevice.cpp
+++ b/libpigpiodpp/src/i2cdevice.cpp
@@ -38,4 +38,24 @@ namespace PiGPIOdpp {
       }
     }
   }
+
+  void I2CDevice::WriteByte(uint8_t targetRegister, uint8_t value) {
+    auto libraryResult = i2c_write_byte_data(this->pi->getId(),
+					     this->handle,
+					     targetRegister,
+					     value);
+    if( libraryResult != 0 ) {
+      throw PiGPIOdException("i2c_write_byte_data", libraryResult);
+    }
+  }
+
+  void I2CDevice::WriteWord(uint8_t targetRegister, uint16_t value) {
+    auto libraryResult = i2c_write_word_data(this->pi->getId(),
+					     this->handle,
+					     targetRegister,
+					     value);
+    if( libraryResult != 0 ) {
+      throw PiGPIOdException("i2c_write_byte_data", libraryResult);
+    }
+  }
 }

--- a/libpigpiodpp/src/i2cdevice.cpp
+++ b/libpigpiodpp/src/i2cdevice.cpp
@@ -4,7 +4,7 @@
 #include "pigpiodpp/pigpiodstubs.hpp"
 #endif
 
-#include "pigpiodpp/pigpiodexceptions.hpp"
+#include "pigpiodpp/pigpiodppexception.hpp"
 
 #include "pigpiodpp/i2cdevice.hpp"
 
@@ -22,7 +22,7 @@ namespace PiGPIOdpp {
 			    this->i2cAddress,
 			    NoOpenFlags);
     if( this->handle < 0 ) {
-      throw PiGPIOdException("i2c_open", this->handle);
+      throw PiGPIOdppException("i2c_open", this->handle);
     }
   }
 
@@ -45,7 +45,7 @@ namespace PiGPIOdpp {
 					     targetRegister,
 					     value);
     if( libraryResult != 0 ) {
-      throw PiGPIOdException("i2c_write_byte_data", libraryResult);
+      throw PiGPIOdppException("i2c_write_byte_data", libraryResult);
     }
   }
 
@@ -55,7 +55,7 @@ namespace PiGPIOdpp {
 					     targetRegister,
 					     value);
     if( libraryResult != 0 ) {
-      throw PiGPIOdException("i2c_write_byte_data", libraryResult);
+      throw PiGPIOdppException("i2c_write_byte_data", libraryResult);
     }
   }
 }

--- a/libpigpiodpp/src/i2cdevice.cpp
+++ b/libpigpiodpp/src/i2cdevice.cpp
@@ -25,4 +25,17 @@ namespace PiGPIOdpp {
       throw PiGPIOdException("i2c_open", this->handle);
     }
   }
+
+  I2CDevice::~I2CDevice() {
+    if( this->handle >= 0 ) {
+      auto res = i2c_close(this->pi->getId(),
+			   this->handle);
+      if( res != 0 ) {
+	// Can't throw from a destructor
+	std::clog << __FUNCTION__
+		  << ": i2c_close failed"
+		  << std::endl;
+      }
+    }
+  }
 }

--- a/libpigpiodpp/src/i2cdevice.cpp
+++ b/libpigpiodpp/src/i2cdevice.cpp
@@ -1,0 +1,28 @@
+#ifdef PIGPIODPP_HAVE_PIGPIO
+#include <pigpiod_if2.h>
+#else
+#include "pigpiodpp/pigpiodstubs.hpp"
+#endif
+
+#include "pigpiodpp/pigpiodexceptions.hpp"
+
+#include "pigpiodpp/i2cdevice.hpp"
+
+namespace PiGPIOdpp {
+  I2CDevice::I2CDevice(const std::shared_ptr<PiManager> owner,
+		       const unsigned int i2cBusId,
+		       const unsigned int i2cBusAddress) :
+    pi(owner),
+    i2cBus(i2cBusId),
+    i2cAddress(i2cBusAddress),
+    handle(-1) {
+    const unsigned int NoOpenFlags = 0;
+    this->handle = i2c_open(this->pi->getId(),
+			    this->i2cBus,
+			    this->i2cAddress,
+			    NoOpenFlags);
+    if( this->handle < 0 ) {
+      throw PiGPIOdException("i2c_open", this->handle);
+    }
+  }
+}

--- a/libpigpiodpp/src/pigpiodstubs.cpp
+++ b/libpigpiodpp/src/pigpiodstubs.cpp
@@ -114,13 +114,31 @@ int i2c_open(int pi, unsigned i2c_bus, unsigned i2c_addr, unsigned i2c_flags) {
 	       << " " << i2c_bus
 	       << " " << i2c_addr
 	       << " " << i2c_flags << std::endl;
-  return 0;
+  return 10;
 }
 
 int i2c_close(int pi, unsigned handle) {
   (*pigpiodOS) << __FUNCTION__
 	       << " " << pi
 	       << " " << handle << std::endl;
+  return 0;
+}
+
+int i2c_write_byte_data(int pi, unsigned handle, unsigned i2c_reg, unsigned bVal) {
+  (*pigpiodOS) << __FUNCTION__
+	       << " " << pi
+	       << " " << handle
+	       << " " << i2c_reg
+	       << " " << bVal << std::endl;
+  return 0;
+}
+
+int i2c_write_word_data(int pi, unsigned handle, unsigned i2c_reg, unsigned wVal) {
+  (*pigpiodOS) << __FUNCTION__
+	       << " " << pi
+	       << " " << handle
+	       << " " << i2c_reg
+	       << " " << wVal << std::endl;
   return 0;
 }
 

--- a/libpigpiodpp/src/pigpiodstubs.cpp
+++ b/libpigpiodpp/src/pigpiodstubs.cpp
@@ -120,7 +120,7 @@ int i2c_open(int pi, unsigned i2c_bus, unsigned i2c_addr, unsigned i2c_flags) {
 int i2c_close(int pi, unsigned handle) {
   (*pigpiodOS) << __FUNCTION__
 	       << " " << pi
-	       << " " << handle;
+	       << " " << handle << std::endl;
   return 0;
 }
 

--- a/libpigpiodpp/src/pigpiodstubs.cpp
+++ b/libpigpiodpp/src/pigpiodstubs.cpp
@@ -117,6 +117,13 @@ int i2c_open(int pi, unsigned i2c_bus, unsigned i2c_addr, unsigned i2c_flags) {
   return 0;
 }
 
+int i2c_close(int pi, unsigned handle) {
+  (*pigpiodOS) << __FUNCTION__
+	       << " " << pi
+	       << " " << handle;
+  return 0;
+}
+
 // =============================================================================
 
 char *pigpio_error(int errnum) {

--- a/libpigpiodpp/src/pigpiodstubs.cpp
+++ b/libpigpiodpp/src/pigpiodstubs.cpp
@@ -108,6 +108,17 @@ int callback_cancel(unsigned callback_id) {
 
 // =============================================================================
 
+int i2c_open(int pi, unsigned i2c_bus, unsigned i2c_addr, unsigned i2c_flags) {
+  (*pigpiodOS) << __FUNCTION__
+	       << " " << pi
+	       << " " << i2c_bus
+	       << " " << i2c_addr
+	       << " " << i2c_flags << std::endl;
+  return 0;
+}
+
+// =============================================================================
+
 char *pigpio_error(int errnum) {
   (*pigpiodOS) << __FUNCTION__
 	       << " " << errnum << std::endl;

--- a/libpigpiodpp/test/CMakeLists.txt
+++ b/libpigpiodpp/test/CMakeLists.txt
@@ -3,6 +3,7 @@ set(srcs test.cpp)
 list(APPEND srcs gpiopulltests.cpp)
 list(APPEND srcs pimanagertests.cpp)
 list(APPEND srcs gpiopintests.cpp)
+list(APPEND srcs i2cdevicetests.cpp)
 
 
 add_executable(PiGPIOdppTest ${srcs})

--- a/libpigpiodpp/test/i2cdevicetests.cpp
+++ b/libpigpiodpp/test/i2cdevicetests.cpp
@@ -1,6 +1,13 @@
 #include <boost/test/unit_test.hpp>
 
+#include "pigpiodpp/pigpiodppexception.hpp"
 #include "pigpiodpp/i2cdevice.hpp"
+
+#ifdef PIGPIODPP_HAVE_PIGPIO
+const bool haveHardware = true;
+#else
+const bool haveHardware = false;
+#endif
 
 BOOST_AUTO_TEST_SUITE( I2CDevice )
 
@@ -11,14 +18,20 @@ BOOST_AUTO_TEST_CASE( Smoke )
   const unsigned int busId = 0;
   const unsigned int deviceId = 0x1;
 
-  PiGPIOdpp::I2CDevice i2cDev(pm, busId, deviceId);
-
-  BOOST_CHECK_EQUAL( i2cDev.getPi(), pm->getId() );
-  BOOST_CHECK_EQUAL( i2cDev.getI2CBus(), busId );
-  BOOST_CHECK_EQUAL( i2cDev.getI2CAddress(), deviceId );
-  BOOST_CHECK( i2cDev.getHandle() >= 0 );
+  if( haveHardware ) {
+    // Expect failure (on a bare Pi)
+    BOOST_CHECK_THROW(PiGPIOdpp::I2CDevice i2cDev(pm, busId, deviceId),
+		      PiGPIOdpp::PiGPIOdppException);
+  } else {
+    PiGPIOdpp::I2CDevice i2cDev(pm, busId, deviceId);
+    
+    BOOST_CHECK_EQUAL( i2cDev.getPi(), pm->getId() );
+    BOOST_CHECK_EQUAL( i2cDev.getI2CBus(), busId );
+    BOOST_CHECK_EQUAL( i2cDev.getI2CAddress(), deviceId );
+    BOOST_CHECK( i2cDev.getHandle() >= 0 );
+  }
 }
-
+  
 BOOST_AUTO_TEST_CASE( WriteByte )
 {
   auto pm = PiGPIOdpp::PiManager::CreatePiManager();
@@ -26,9 +39,15 @@ BOOST_AUTO_TEST_CASE( WriteByte )
   const unsigned int busId = 0;
   const unsigned int deviceId = 0x1;
 
-  PiGPIOdpp::I2CDevice i2cDev(pm, busId, deviceId);
-
-  BOOST_CHECK_NO_THROW( i2cDev.WriteByte(1, 2) );
+  if( haveHardware ) {
+    // Expect failure (on a bare Pi)
+    BOOST_CHECK_THROW(PiGPIOdpp::I2CDevice i2cDev(pm, busId, deviceId),
+		      PiGPIOdpp::PiGPIOdppException);
+  } else {
+    PiGPIOdpp::I2CDevice i2cDev(pm, busId, deviceId);
+  
+    BOOST_CHECK_NO_THROW( i2cDev.WriteByte(1, 2) );
+  }
 }
 
 BOOST_AUTO_TEST_CASE( WriteWord )
@@ -38,9 +57,15 @@ BOOST_AUTO_TEST_CASE( WriteWord )
   const unsigned int busId = 0;
   const unsigned int deviceId = 0x1;
 
-  PiGPIOdpp::I2CDevice i2cDev(pm, busId, deviceId);
+  if( haveHardware ) {
+    // Expect failure (on a bare Pi)
+    BOOST_CHECK_THROW(PiGPIOdpp::I2CDevice i2cDev(pm, busId, deviceId),
+		      PiGPIOdpp::PiGPIOdppException);
+  } else {
+    PiGPIOdpp::I2CDevice i2cDev(pm, busId, deviceId);
 
-  BOOST_CHECK_NO_THROW( i2cDev.WriteWord(4, 5) );
+    BOOST_CHECK_NO_THROW( i2cDev.WriteWord(4, 5) );
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libpigpiodpp/test/i2cdevicetests.cpp
+++ b/libpigpiodpp/test/i2cdevicetests.cpp
@@ -19,4 +19,28 @@ BOOST_AUTO_TEST_CASE( Smoke )
   BOOST_CHECK( i2cDev.getHandle() >= 0 );
 }
 
+BOOST_AUTO_TEST_CASE( WriteByte )
+{
+  auto pm = PiGPIOdpp::PiManager::CreatePiManager();
+
+  const unsigned int busId = 0;
+  const unsigned int deviceId = 0x1;
+
+  PiGPIOdpp::I2CDevice i2cDev(pm, busId, deviceId);
+
+  BOOST_CHECK_NO_THROW( i2cDev.WriteByte(1, 2) );
+}
+
+BOOST_AUTO_TEST_CASE( WriteWord )
+{
+  auto pm = PiGPIOdpp::PiManager::CreatePiManager();
+
+  const unsigned int busId = 0;
+  const unsigned int deviceId = 0x1;
+
+  PiGPIOdpp::I2CDevice i2cDev(pm, busId, deviceId);
+
+  BOOST_CHECK_NO_THROW( i2cDev.WriteWord(4, 5) );
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/libpigpiodpp/test/i2cdevicetests.cpp
+++ b/libpigpiodpp/test/i2cdevicetests.cpp
@@ -1,0 +1,22 @@
+#include <boost/test/unit_test.hpp>
+
+#include "pigpiodpp/i2cdevice.hpp"
+
+BOOST_AUTO_TEST_SUITE( I2CDevice )
+
+BOOST_AUTO_TEST_CASE( Smoke )
+{
+  auto pm = PiGPIOdpp::PiManager::CreatePiManager();
+
+  const unsigned int busId = 0;
+  const unsigned int deviceId = 0x1;
+
+  PiGPIOdpp::I2CDevice i2cDev(pm, busId, deviceId);
+
+  BOOST_CHECK_EQUAL( i2cDev.getPi(), pm->getId() );
+  BOOST_CHECK_EQUAL( i2cDev.getI2CBus(), busId );
+  BOOST_CHECK_EQUAL( i2cDev.getI2CAddress(), deviceId );
+  BOOST_CHECK( i2cDev.getHandle() >= 0 );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libpigpiodpp/test/pimanagertests.cpp
+++ b/libpigpiodpp/test/pimanagertests.cpp
@@ -2,6 +2,7 @@
 
 #include "pigpiodpp/pimanager.hpp"
 #include "pigpiodpp/gpiopin.hpp"
+#include "pigpiodpp/pigpiodppexception.hpp"
 
 BOOST_AUTO_TEST_SUITE( PiManager )
 
@@ -60,7 +61,7 @@ BOOST_AUTO_TEST_CASE( SmokeGPIOPinException )
   BOOST_REQUIRE( gpio1 );
 
   BOOST_CHECK_THROW( gpio1->SetMode( PiGPIOdpp::GPIOMode::Output ),
-		     PiGPIOdpp::PiGPIOdException );
+		     PiGPIOdpp::PiGPIOdppException );
 }
 
 

--- a/libpigpiodpp/test/pimanagertests.cpp
+++ b/libpigpiodpp/test/pimanagertests.cpp
@@ -2,7 +2,6 @@
 
 #include "pigpiodpp/pimanager.hpp"
 #include "pigpiodpp/gpiopin.hpp"
-#include "pigpiodpp/pigpiodexceptions.hpp"
 
 BOOST_AUTO_TEST_SUITE( PiManager )
 


### PR DESCRIPTION
A very simple wrapper around the I2C calls for `libpigpiodpp` Also renamed the exception from the library to match the new library name.