### PR TITLE
Update boost location on build machine

### DIFF
--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -3,7 +3,7 @@
 parameters:
   srcDir: ''
   bldDir: ''
-  cmakeArgs: '-DBoost_DEBUG=ON -DBOOST_ROOT=/opt/hostedtoolcache/boost/1.69.0/ -DBoost_ARCHITECTURE=-x64'
+  cmakeArgs: '-DBoost_DEBUG=ON -DBOOST_ROOT=/opt/hostedtoolcache/boost/1.69.0/x64 -DBoost_ARCHITECTURE=-x64'
   cmakeExtraArgs: ''
   makeExtraArgs: ''
   makeTarget: ''
@@ -14,7 +14,7 @@ steps:
     echo ""
     locate libboost
   displayName: "Boost debugging"
-  condition: True
+  condition: False
   
 - task: Bash@3
   displayName: "Install xerces library"

--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -9,6 +9,12 @@ parameters:
   makeTarget: ''
 
 steps:
+- bash: |
+    sudo updatedb
+    echo ""
+    locate libboost
+  displayName: "Boost debugging"
+  
 - task: Bash@3
   displayName: "Install xerces library"
   inputs:

--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -3,7 +3,7 @@
 parameters:
   srcDir: ''
   bldDir: ''
-  cmakeArgs: '-DBoost_DEBUG=ON -DBOOST_ROOT=/usr/local/share/boost/1.69.0 -DBoost_ARCHITECTURE=-x64'
+  cmakeArgs: '-DBoost_DEBUG=ON -DBOOST_ROOT=/opt/hostedtoolcache/boost/1.69.0/ -DBoost_ARCHITECTURE=-x64'
   cmakeExtraArgs: ''
   makeExtraArgs: ''
   makeTarget: ''
@@ -14,6 +14,7 @@ steps:
     echo ""
     locate libboost
   displayName: "Boost debugging"
+  condition: True
   
 - task: Bash@3
   displayName: "Install xerces library"


### PR DESCRIPTION
Latest update to the MS images had moved the location of the boost libraries. Update builds to reflect this.