### PR TITLE
Abstract CabinetService

### DIFF
--- a/apps/cabinet/main.cpp
+++ b/apps/cabinet/main.cpp
@@ -2,7 +2,7 @@
 
 #include "lineside/jsonrpc/rpcserver.hpp"
 #include "lineside/jsonrpc/cpphttplibconnector.hpp"
-
+#include "lineside/jsonrpc/cabinetserviceimpl.hpp"
 
 /*
   Some sample calls
@@ -32,7 +32,9 @@ int main() {
   std::cout << "================" << std::endl;
   std::cout << std::endl;
 
-  Lineside::JsonRPC::RPCServer rpcServer;
+  auto csi = std::make_shared<Lineside::JsonRPC::CabinetServiceImpl>();
+  
+  Lineside::JsonRPC::RPCServer rpcServer(csi);
 
   Lineside::JsonRPC::CppHttpLibServerConnector httpServer(rpcServer.GetServer(),
 							  "0.0.0.0",

--- a/liblineside/include/lineside/jsonrpc/cabinetservice.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetservice.hpp
@@ -7,25 +7,20 @@
 
 namespace Lineside {
   namespace JsonRPC {
+    //! Interface for use by the RPC side
     class CabinetService {
     public:
-      CabinetService();
-
-      /*
-	All have non-void return in order to ensure we get errors back
-       */
+      virtual ~CabinetService() {}
       
-      bool SetMultiAspectSignal(const std::string id,
-				const Lineside::SignalState state,
-				const Lineside::SignalFlash flash,
-				const unsigned int feather);
+      virtual bool SetMultiAspectSignal(const std::string id,
+					const Lineside::SignalState state,
+					const Lineside::SignalFlash flash,
+					const unsigned int feather) = 0;
 
-      bool SetTurnout(const std::string id,
-		      const Lineside::TurnoutState state);
+      virtual bool SetTurnout(const std::string id,
+			      const Lineside::TurnoutState state) = 0;
 
-      bool GetTrackCircuit(const std::string id);
-		      
-    private:
+      virtual bool GetTrackCircuit(const std::string id) = 0;
     };
   }
 }

--- a/liblineside/include/lineside/jsonrpc/cabinetservice.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetservice.hpp
@@ -5,6 +5,8 @@
 #include "lineside/signalflash.hpp"
 #include "lineside/turnoutstate.hpp"
 
+#include "lineside/jsonrpc/cabinetserviceresponse.hpp"
+
 namespace Lineside {
   namespace JsonRPC {
     //! Interface for use by the RPC side
@@ -12,13 +14,17 @@ namespace Lineside {
     public:
       virtual ~CabinetService() {}
       
-      virtual bool SetMultiAspectSignal(const std::string id,
-					const Lineside::SignalState state,
-					const Lineside::SignalFlash flash,
-					const unsigned int feather) = 0;
-
-      virtual bool SetTurnout(const std::string id,
-			      const Lineside::TurnoutState state) = 0;
+      virtual
+      CabinetServiceResponse
+      SetMultiAspectSignal(const std::string id,
+			   const Lineside::SignalState state,
+			   const Lineside::SignalFlash flash,
+			   const unsigned int feather) = 0;
+      
+      virtual
+      CabinetServiceResponse
+      SetTurnout(const std::string id,
+		 const Lineside::TurnoutState state) = 0;
 
       virtual bool GetTrackCircuit(const std::string id) = 0;
     };

--- a/liblineside/include/lineside/jsonrpc/cabinetserviceimpl.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetserviceimpl.hpp
@@ -9,13 +9,17 @@ namespace Lineside {
     public:
       CabinetServiceImpl();
 
-      virtual bool SetMultiAspectSignal(const std::string id,
-					const Lineside::SignalState state,
-					const Lineside::SignalFlash flash,
-					const unsigned int feather) override;
+      virtual
+      CabinetServiceResponse
+      SetMultiAspectSignal(const std::string id,
+			   const Lineside::SignalState state,
+			   const Lineside::SignalFlash flash,
+			   const unsigned int feather) override;
 
-      virtual bool SetTurnout(const std::string id,
-			      const Lineside::TurnoutState state) override;
+      virtual
+      CabinetServiceResponse
+      SetTurnout(const std::string id,
+		 const Lineside::TurnoutState state) override;
 
       virtual bool GetTrackCircuit(const std::string id) override;
     };

--- a/liblineside/include/lineside/jsonrpc/cabinetserviceimpl.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetserviceimpl.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "lineside/jsonrpc/cabinetservice.hpp"
+
+namespace Lineside {
+  namespace JsonRPC {
+    //! Implementation of the CabinetService
+    class CabinetServiceImpl : public CabinetService {
+    public:
+      CabinetServiceImpl();
+
+      virtual bool SetMultiAspectSignal(const std::string id,
+					const Lineside::SignalState state,
+					const Lineside::SignalFlash flash,
+					const unsigned int feather) override;
+
+      virtual bool SetTurnout(const std::string id,
+			      const Lineside::TurnoutState state) override;
+
+      virtual bool GetTrackCircuit(const std::string id) override;
+    };
+  }
+}

--- a/liblineside/include/lineside/jsonrpc/cabinetserviceresponse.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetserviceresponse.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace Lineside {
+  namespace JsonRPC {
+    //! Enum for responses update instructions to a cabinet
+    /*!
+      We have this because a JSON-RPC notification can't even
+      return an error code, even if the called routine throws
+      an exception.
+      By returning a value of this type (which will always indicate
+      success), if there is an exception, it will be communicated back
+      as a server error.
+     */
+    enum class CabinetServiceResponse { Success };
+  }
+}

--- a/liblineside/include/lineside/jsonrpc/jsonconvertors.hpp
+++ b/liblineside/include/lineside/jsonrpc/jsonconvertors.hpp
@@ -7,6 +7,8 @@
 #include "lineside/signalflash.hpp"
 #include "lineside/turnoutstate.hpp"
 
+#include "lineside/jsonrpc/cabinetserviceresponse.hpp"
+
 namespace Lineside {
   void to_json(nlohmann::json &j, const ItemId& id);
   void from_json(const nlohmann::json &j, Lineside::ItemId& id);
@@ -29,5 +31,10 @@ namespace Lineside {
 			       {
 				{Lineside::TurnoutState::Straight, ToString(Lineside::TurnoutState::Straight)},
 				{Lineside::TurnoutState::Curved, ToString(Lineside::TurnoutState::Curved)}
+			       })
+
+  NLOHMANN_JSON_SERIALIZE_ENUM(Lineside::JsonRPC::CabinetServiceResponse,
+			       {
+				{Lineside::JsonRPC::CabinetServiceResponse::Success, "Success"}
 			       })
 }

--- a/liblineside/include/lineside/jsonrpc/rpcserver.hpp
+++ b/liblineside/include/lineside/jsonrpc/rpcserver.hpp
@@ -8,14 +8,14 @@ namespace Lineside {
   namespace JsonRPC {
     class RPCServer {
     public:
-      RPCServer();
+      RPCServer(std::shared_ptr<CabinetService> cabinet);
 
       jsonrpccxx::JsonRpc2Server& GetServer() {
 	std::cerr << __FUNCTION__ << ": Needs better solution" << std::endl;
 	return this->rpcServer;
       }
     private:
-      std::unique_ptr<CabinetService> cabinet;
+      std::shared_ptr<CabinetService> cabinet;
       jsonrpccxx::JsonRpc2Server rpcServer;
     };
   }

--- a/liblineside/src/jsonrpc/CMakeLists.txt
+++ b/liblineside/src/jsonrpc/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(srcs)
 
 list(APPEND srcs cpphttplibconnector.cpp)
-list(APPEND srcs cabinetservice.cpp)
+list(APPEND srcs cabinetserviceimpl.cpp)
 list(APPEND srcs jsonconvertors.cpp)
 list(APPEND srcs rpcserver.cpp)
 

--- a/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
+++ b/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
@@ -1,16 +1,15 @@
 #include <iostream>
-#include "lineside/jsonrpc/cabinetservice.hpp"
-
+#include "lineside/jsonrpc/cabinetserviceimpl.hpp"
 
 namespace Lineside {
   namespace JsonRPC {
     
-    CabinetService::CabinetService() {}
+    CabinetServiceImpl::CabinetServiceImpl() {}
       
-    bool CabinetService::SetMultiAspectSignal(const std::string id,
-					      const Lineside::SignalState state,
-					      const Lineside::SignalFlash flash,
-					      const unsigned int feather) {
+    bool CabinetServiceImpl::SetMultiAspectSignal(const std::string id,
+						  const Lineside::SignalState state,
+						  const Lineside::SignalFlash flash,
+						  const unsigned int feather) {
       std::cout << __FUNCTION__ << ": "
 		<< id << " "
 		<< state << " "
@@ -19,8 +18,8 @@ namespace Lineside {
       return true;
     }
 
-    bool CabinetService::SetTurnout(const std::string id,
-				    const Lineside::TurnoutState state) {
+    bool CabinetServiceImpl::SetTurnout(const std::string id,
+					const Lineside::TurnoutState state) {
       std::cout << __FUNCTION__ << ": "
 		<< id << " "
 		<< state << std::endl;
@@ -28,7 +27,7 @@ namespace Lineside {
       return true;
     }
 
-    bool CabinetService::GetTrackCircuit(const std::string id) {
+    bool CabinetServiceImpl::GetTrackCircuit(const std::string id) {
       Lineside::ItemId targetId;
       targetId.Parse(id);
       std::cout << __FUNCTION__ << ": "

--- a/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
+++ b/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
@@ -6,25 +6,27 @@ namespace Lineside {
     
     CabinetServiceImpl::CabinetServiceImpl() {}
       
-    bool CabinetServiceImpl::SetMultiAspectSignal(const std::string id,
-						  const Lineside::SignalState state,
-						  const Lineside::SignalFlash flash,
-						  const unsigned int feather) {
+    CabinetServiceResponse
+    CabinetServiceImpl::SetMultiAspectSignal(const std::string id,
+					     const Lineside::SignalState state,
+					     const Lineside::SignalFlash flash,
+					     const unsigned int feather) {
       std::cout << __FUNCTION__ << ": "
 		<< id << " "
 		<< state << " "
 		<< flash << " "
 		<< feather << std::endl;
-      return true;
+      return CabinetServiceResponse::Success;
     }
 
-    bool CabinetServiceImpl::SetTurnout(const std::string id,
-					const Lineside::TurnoutState state) {
+    CabinetServiceResponse
+    CabinetServiceImpl::SetTurnout(const std::string id,
+				   const Lineside::TurnoutState state) {
       std::cout << __FUNCTION__ << ": "
 		<< id << " "
 		<< state << std::endl;
-
-      return true;
+      
+      return CabinetServiceResponse::Success;
     }
 
     bool CabinetServiceImpl::GetTrackCircuit(const std::string id) {

--- a/liblineside/src/jsonrpc/rpcserver.cpp
+++ b/liblineside/src/jsonrpc/rpcserver.cpp
@@ -5,8 +5,8 @@
 
 namespace Lineside {
   namespace JsonRPC {
-    RPCServer::RPCServer() :
-      cabinet(std::make_unique<CabinetService>()),
+    RPCServer::RPCServer(std::shared_ptr<CabinetService> cabinet) :
+      cabinet(cabinet),
       rpcServer() {
       this->rpcServer.Add("SetMultiAspectSignal",
 			  jsonrpccxx::GetHandle(&CabinetService::SetMultiAspectSignal,


### PR DESCRIPTION
Make the `CabinetService` an abstract interface, and take what was previously written as an implementation of the interface. Then, the `RPCServer` itself only has a dependency on the interface, and we can avoid dragging all the the details of the permanent way items into the`RPCServer`.

Also, define a custom `CabinetServiceResponse` type, which is a single valued `enum class`. This needed because JSON-RPC notifications can't even return errors. By returning a type (which will always indicated success), we ensure that if an exception is thrown, it will be caught and returned to the user as a server error, and not silently lost.