### PR TITLE
Update to RPC service interface

### DIFF
--- a/apps/cabinet/main.cpp
+++ b/apps/cabinet/main.cpp
@@ -20,7 +20,7 @@
     https://www.jsonrpc.org/specification#notification
     Currently, the return types are all bool; should improve this
 
-  curl http://localhost:8483/jsonrpc -H "Content-Type application/json" --data '{ "method":"SetMultiAspectSignal", "params":{"id":"00:1a:2b:3c", "state":"DoubleYellow", "flash":"Steady", "feather":0}, "jsonrpc": "2.0" }'
+  curl http://localhost:8483/jsonrpc -H "Content-Type application/json" --data '{ "method":"SetMultiAspectSignal", "params":{"id":"00:1a:2b:3c", "state":"DoubleYellow", "flash":"Steady", "feather":0}, "id":1, "jsonrpc": "2.0" }'
 
   curl http://localhost:8483/jsonrpc -H "Content-Type application/json" --data '{ "method":"SetTurnout", "params":{"id":"00:1a:2b:3c", "state":"Straight"}, "id":1, "jsonrpc": "2.0" }'
 

--- a/liblineside/include/lineside/jsonrpc/cabinetservice.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetservice.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "lineside/itemid.hpp"
 #include "lineside/signalstate.hpp"
 #include "lineside/signalflash.hpp"
@@ -29,10 +31,10 @@ namespace Lineside {
        */
       virtual
       CabinetServiceResponse
-      SetMultiAspectSignal(const std::string id,
-			   const std::string state,
-			   const std::string flash,
-			   const unsigned int feather) = 0;
+      SetMultiAspectSignalString(const std::string id,
+				 const std::string state,
+				 const std::string flash,
+				 const unsigned int feather) = 0;
 
       //! Function to set the state of a turnout
       virtual
@@ -47,8 +49,8 @@ namespace Lineside {
        */
       virtual
       CabinetServiceResponse
-      SetTurnout(const std::string id,
-		 const std::string state) = 0;
+      SetTurnoutString(const std::string id,
+		       const std::string state) = 0;
 
       //! Function to get the state of a track circuit
       virtual bool GetTrackCircuit(const Lineside::ItemId id) = 0;
@@ -58,7 +60,7 @@ namespace Lineside {
 	This is a dupicate with string arguments in case there are issues
 	with converting the custom types.
        */
-      virtual bool GetTrackCircuit(const std::string id) = 0;
+      virtual bool GetTrackCircuitString(const std::string id) = 0;
     };
   }
 }

--- a/liblineside/include/lineside/jsonrpc/cabinetservice.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetservice.hpp
@@ -46,7 +46,7 @@ namespace Lineside {
 	with converting the custom types.
        */
       virtual
-      CabinetServiceRespose
+      CabinetServiceResponse
       SetTurnout(const std::string id,
 		 const std::string state) = 0;
 

--- a/liblineside/include/lineside/jsonrpc/cabinetservice.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetservice.hpp
@@ -13,18 +13,32 @@ namespace Lineside {
     class CabinetService {
     public:
       virtual ~CabinetService() {}
-      
+
       virtual
       CabinetServiceResponse
-      SetMultiAspectSignal(const std::string id,
+      SetMultiAspectSignal(const Lineside::ItemId id,
 			   const Lineside::SignalState state,
 			   const Lineside::SignalFlash flash,
 			   const unsigned int feather) = 0;
       
       virtual
       CabinetServiceResponse
-      SetTurnout(const std::string id,
+      SetMultiAspectSignal(const std::string id,
+			   const std::string state,
+			   const std::string flash,
+			   const unsigned int feather) = 0;
+
+      virtual
+      CabinetServiceResponse
+      SetTurnout(const Lineside::ItemId id,
 		 const Lineside::TurnoutState state) = 0;
+      
+      virtual
+      CabinetServiceRespose
+      SetTurnout(const std::string id,
+		 const std::string state) = 0;
+
+      virtual bool GetTrackCircuit(const Lineside::ItemId id) = 0;
 
       virtual bool GetTrackCircuit(const std::string id) = 0;
     };

--- a/liblineside/include/lineside/jsonrpc/cabinetservice.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetservice.hpp
@@ -14,13 +14,19 @@ namespace Lineside {
     public:
       virtual ~CabinetService() {}
 
+      //! Function to set the state of a multiaspect signal
       virtual
       CabinetServiceResponse
       SetMultiAspectSignal(const Lineside::ItemId id,
 			   const Lineside::SignalState state,
 			   const Lineside::SignalFlash flash,
 			   const unsigned int feather) = 0;
-      
+
+      //! Function to set the state of a multiaspect signal
+      /*!
+	This is a dupicate with string arguments in case there are issues
+	with converting the custom types.
+       */
       virtual
       CabinetServiceResponse
       SetMultiAspectSignal(const std::string id,
@@ -28,18 +34,30 @@ namespace Lineside {
 			   const std::string flash,
 			   const unsigned int feather) = 0;
 
+      //! Function to set the state of a turnout
       virtual
       CabinetServiceResponse
       SetTurnout(const Lineside::ItemId id,
 		 const Lineside::TurnoutState state) = 0;
       
+      //! Function to set the state of a turnout
+      /*!
+	This is a dupicate with string arguments in case there are issues
+	with converting the custom types.
+       */
       virtual
       CabinetServiceRespose
       SetTurnout(const std::string id,
 		 const std::string state) = 0;
 
+      //! Function to get the state of a track circuit
       virtual bool GetTrackCircuit(const Lineside::ItemId id) = 0;
 
+      //! Function to get the state of a track circuit
+      /*!
+	This is a dupicate with string arguments in case there are issues
+	with converting the custom types.
+       */
       virtual bool GetTrackCircuit(const std::string id) = 0;
     };
   }

--- a/liblineside/include/lineside/jsonrpc/cabinetserviceimpl.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetserviceimpl.hpp
@@ -18,10 +18,10 @@ namespace Lineside {
       
       virtual
       CabinetServiceResponse
-      SetMultiAspectSignal(const std::string id,
-			   const std::string state,
-			   const std::string flash,
-			   const unsigned int feather) override;
+      SetMultiAspectSignalString(const std::string id,
+				 const std::string state,
+				 const std::string flash,
+				 const unsigned int feather) override;
 
       virtual
       CabinetServiceResponse
@@ -30,12 +30,12 @@ namespace Lineside {
       
       virtual
       CabinetServiceResponse
-      SetTurnout(const std::string id,
-		 const std::string state) override;
+      SetTurnoutString(const std::string id,
+		       const std::string state) override;
 
       virtual bool GetTrackCircuit(const Lineside::ItemId id) override;
 
-      virtual bool GetTrackCircuit(const std::string id) override;
+      virtual bool GetTrackCircuitString(const std::string id) override;
     };
   }
 }

--- a/liblineside/include/lineside/jsonrpc/cabinetserviceimpl.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetserviceimpl.hpp
@@ -29,7 +29,7 @@ namespace Lineside {
 		 const Lineside::TurnoutState state) override;
       
       virtual
-      CabinetServiceRespose
+      CabinetServiceResponse
       SetTurnout(const std::string id,
 		 const std::string state) override;
 

--- a/liblineside/include/lineside/jsonrpc/cabinetserviceimpl.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetserviceimpl.hpp
@@ -11,15 +11,29 @@ namespace Lineside {
 
       virtual
       CabinetServiceResponse
-      SetMultiAspectSignal(const std::string id,
+      SetMultiAspectSignal(const Lineside::ItemId id,
 			   const Lineside::SignalState state,
 			   const Lineside::SignalFlash flash,
+			   const unsigned int feather) override;
+      
+      virtual
+      CabinetServiceResponse
+      SetMultiAspectSignal(const std::string id,
+			   const std::string state,
+			   const std::string flash,
 			   const unsigned int feather) override;
 
       virtual
       CabinetServiceResponse
-      SetTurnout(const std::string id,
+      SetTurnout(const Lineside::ItemId id,
 		 const Lineside::TurnoutState state) override;
+      
+      virtual
+      CabinetServiceRespose
+      SetTurnout(const std::string id,
+		 const std::string state) override;
+
+      virtual bool GetTrackCircuit(const Lineside::ItemId id) override;
 
       virtual bool GetTrackCircuit(const std::string id) override;
     };

--- a/liblineside/include/lineside/turnoutstate.hpp
+++ b/liblineside/include/lineside/turnoutstate.hpp
@@ -3,7 +3,10 @@
 #include <iostream>
 #include <string>
 
+#include "lineside/parse.hpp"
+
 namespace Lineside {
+  //! Enumeration to describe possible states of turnouts
   enum class TurnoutState { Straight,
 			    Curved
   };
@@ -11,4 +14,8 @@ namespace Lineside {
   std::ostream& operator<<(std::ostream& os, const TurnoutState s);
 
   std::string ToString( const TurnoutState s );
+
+  //! Template specialisation to parse a string to a TurnoutState
+  template<>
+  TurnoutState Parse<TurnoutState>(const std::string& src );
 }

--- a/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
+++ b/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
@@ -7,7 +7,7 @@ namespace Lineside {
     CabinetServiceImpl::CabinetServiceImpl() {}
       
     CabinetServiceResponse
-    CabinetServiceImpl::SetMultiAspectSignal(const std::string id,
+    CabinetServiceImpl::SetMultiAspectSignal(const Lineside::ItemId id,
 					     const Lineside::SignalState state,
 					     const Lineside::SignalFlash flash,
 					     const unsigned int feather) {
@@ -20,7 +20,19 @@ namespace Lineside {
     }
 
     CabinetServiceResponse
-    CabinetServiceImpl::SetTurnout(const std::string id,
+    CabinetServiceImpl::SetMultiAspectSignal(const std::string id,
+					     const std::string state,
+					     const std::string flash,
+					     const unsigned int feather ) {
+      Lineside::ItemId idObj;
+      idObj.Parse(id);
+      auto stateEnum = Lineside::Parse<Lineside::SignalState>(state);
+      auto flashEnum = Lineside::Parse<Lineside::SignalFlash>(flash);
+      return this->SetMultiAspectSignal(idObj, stateEnum, flashEnum, feather);
+    }
+
+    CabinetServiceResponse
+    CabinetServiceImpl::SetTurnout(const Lineside::ItemId id,
 				   const Lineside::TurnoutState state) {
       std::cout << __FUNCTION__ << ": "
 		<< id << " "
@@ -29,11 +41,9 @@ namespace Lineside {
       return CabinetServiceResponse::Success;
     }
 
-    bool CabinetServiceImpl::GetTrackCircuit(const std::string id) {
-      Lineside::ItemId targetId;
-      targetId.Parse(id);
+    bool CabinetServiceImpl::GetTrackCircuit(const Lineside::ItemId id) {
       std::cout << __FUNCTION__ << ": "
-		<< targetId << std::endl;
+		<< id << std::endl;
       return true;
     }
   }

--- a/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
+++ b/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
@@ -20,10 +20,10 @@ namespace Lineside {
     }
 
     CabinetServiceResponse
-    CabinetServiceImpl::SetMultiAspectSignal(const std::string id,
-					     const std::string state,
-					     const std::string flash,
-					     const unsigned int feather ) {
+    CabinetServiceImpl::SetMultiAspectSignalString(const std::string id,
+						   const std::string state,
+						   const std::string flash,
+						   const unsigned int feather ) {
       Lineside::ItemId idObj;
       idObj.Parse(id);
       auto stateEnum = Lineside::Parse<Lineside::SignalState>(state);
@@ -41,10 +41,25 @@ namespace Lineside {
       return CabinetServiceResponse::Success;
     }
 
+    CabinetServiceResponse
+    CabinetServiceImpl::SetTurnoutString(const std::string id,
+					 const std::string state) {
+      Lineside::ItemId idObj;
+      idObj.Parse(id);
+      auto stateEnum = Lineside::Parse<Lineside::TurnoutState>(state);
+      return this->SetTurnout(idObj, stateEnum);
+    }
+
     bool CabinetServiceImpl::GetTrackCircuit(const Lineside::ItemId id) {
       std::cout << __FUNCTION__ << ": "
 		<< id << std::endl;
       return true;
+    }
+
+    bool CabinetServiceImpl::GetTrackCircuitString(const std::string id) {
+      Lineside::ItemId idObj;
+      idObj.Parse(id);
+      return this->GetTrackCircuit(idObj);
     }
   }
 }

--- a/liblineside/src/jsonrpc/rpcserver.cpp
+++ b/liblineside/src/jsonrpc/rpcserver.cpp
@@ -8,18 +8,19 @@ namespace Lineside {
     RPCServer::RPCServer(std::shared_ptr<CabinetService> cabinet) :
       cabinet(cabinet),
       rpcServer() {
+      // Due to difficulties handling custom types, need to use 'String' versions
       this->rpcServer.Add("SetMultiAspectSignal",
 			  jsonrpccxx::GetHandle(&CabinetService::SetMultiAspectSignalString,
 						*(this->cabinet.get())),
 			  {"id", "state", "flash", "feather"});
       
       this->rpcServer.Add("SetTurnout",
-			  jsonrpccxx::GetHandle(&CabinetService::SetTurnout,
+			  jsonrpccxx::GetHandle(&CabinetService::SetTurnoutString,
 						*(this->cabinet.get())),
 			  {"id", "state"});
       
       this->rpcServer.Add("GetTrackCircuit",
-			  jsonrpccxx::GetHandle(&CabinetService::GetTrackCircuit,
+			  jsonrpccxx::GetHandle(&CabinetService::GetTrackCircuitString,
 						*(this->cabinet.get())),
 			  {"id"});
     }

--- a/liblineside/src/jsonrpc/rpcserver.cpp
+++ b/liblineside/src/jsonrpc/rpcserver.cpp
@@ -9,7 +9,7 @@ namespace Lineside {
       cabinet(cabinet),
       rpcServer() {
       this->rpcServer.Add("SetMultiAspectSignal",
-			  jsonrpccxx::GetHandle(&CabinetService::SetMultiAspectSignal,
+			  jsonrpccxx::GetHandle(&CabinetService::SetMultiAspectSignalString,
 						*(this->cabinet.get())),
 			  {"id", "state", "flash", "feather"});
       

--- a/liblineside/src/turnoutstate.cpp
+++ b/liblineside/src/turnoutstate.cpp
@@ -36,4 +36,24 @@ namespace Lineside {
     
     return res;
   }
+
+  template<>
+  TurnoutState Parse<TurnoutState>(const std::string& src) {
+    if( convertor.empty() ) {
+      initconvertor();
+    }
+
+    try {
+      TurnoutState tState;
+      tState = convertor.right.at(src);
+      return tState;
+    }
+    catch( std::out_of_range& e ) {
+      std::stringstream msg;
+      msg << "Could not parse '";
+      msg << src;
+      msg << "' to TurnoutState";
+      throw std::invalid_argument(msg.str());
+    }
+  }
 }

--- a/liblineside/test/turnoutstatetests.cpp
+++ b/liblineside/test/turnoutstatetests.cpp
@@ -34,4 +34,13 @@ BOOST_AUTO_TEST_CASE( StreamInsertion )
   res.str(std::string());
 }
 
+BOOST_AUTO_TEST_CASE( Parse )
+{
+  auto straight = Lineside::Parse<Lineside::TurnoutState>("Straight");
+  BOOST_CHECK_EQUAL( straight, Lineside::TurnoutState::Straight );
+
+  auto curved = Lineside::Parse<Lineside::TurnoutState>("Curved");
+  BOOST_CHECK_EQUAL( curved, Lineside::TurnoutState::Curved );
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Update the abstract RPC service interface to have 'typed' and 'string' versions. This is because JSON-RPC-CXX has trouble with automatically parsing the `enum class` types. The 'string' versions take the arguments as `std::string`, convert to the required types, and then call the 'typed' version. The method names as suffixed with `String` because getting pointers to overloaded functions is tedious.

Also add an overload to parse a `TurnoutState` from a string, and correct the `curl` call for setting a multiaspect signal (was silently failing).