### PR TITLE
Add static Parse for ItemId

### DIFF
--- a/liblineside/include/lineside/itemid.hpp
+++ b/liblineside/include/lineside/itemid.hpp
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <random>
 
+#include "lineside/parse.hpp"
+
 //! Namespace for this project
 namespace Lineside {
   //! Class to hold an identifier for an item.
@@ -58,12 +60,15 @@ namespace Lineside {
       return !((*this)==item);
     }
 
+    //! Convert to a string
     std::string ToString() const;
 
+    //! Create a zero-valued id
     static ItemId Nil() {
       return ItemId();
     }
 
+    //! Create a random id
     static ItemId Random() {
       unsigned long seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
       std::default_random_engine rand(seed);
@@ -80,6 +85,10 @@ namespace Lineside {
 
   //! Stream extraction operator for Lineside::ItemId objects
   std::istream& operator>>(std::istream& is, Lineside::ItemId& item);
+
+  //! Template specialisation for parsing
+  template<>
+  ItemId Parse<ItemId>(const std::string& src );
 }
 
 

--- a/liblineside/src/itemid.cpp
+++ b/liblineside/src/itemid.cpp
@@ -89,4 +89,11 @@ namespace Lineside {
     s << (*this);
     return s.str();
   }
+
+  template<>
+  ItemId Parse<ItemId>(const std::string& src ) {
+    ItemId result;
+    result.Parse(src);
+    return result;
+  }
 }

--- a/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
+++ b/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
@@ -24,8 +24,7 @@ namespace Lineside {
 						   const std::string state,
 						   const std::string flash,
 						   const unsigned int feather ) {
-      Lineside::ItemId idObj;
-      idObj.Parse(id);
+      auto idObj = Lineside::Parse<ItemId>(id);
       auto stateEnum = Lineside::Parse<Lineside::SignalState>(state);
       auto flashEnum = Lineside::Parse<Lineside::SignalFlash>(flash);
       return this->SetMultiAspectSignal(idObj, stateEnum, flashEnum, feather);
@@ -44,8 +43,7 @@ namespace Lineside {
     CabinetServiceResponse
     CabinetServiceImpl::SetTurnoutString(const std::string id,
 					 const std::string state) {
-      Lineside::ItemId idObj;
-      idObj.Parse(id);
+      auto idObj = Lineside::Parse<ItemId>(id);
       auto stateEnum = Lineside::Parse<Lineside::TurnoutState>(state);
       return this->SetTurnout(idObj, stateEnum);
     }
@@ -57,8 +55,7 @@ namespace Lineside {
     }
 
     bool CabinetServiceImpl::GetTrackCircuitString(const std::string id) {
-      Lineside::ItemId idObj;
-      idObj.Parse(id);
+      auto idObj = Lineside::Parse<ItemId>(id);
       return this->GetTrackCircuit(idObj);
     }
   }

--- a/liblineside/src/xml/pwitemdatareader.cpp
+++ b/liblineside/src/xml/pwitemdatareader.cpp
@@ -10,10 +10,7 @@ namespace Lineside {
       }
 
       auto idStr = GetAttributeByName(pwItemElement, "id");
-
-      Lineside::ItemId result;
-      result.Parse(idStr);
-      return result;
+      return Lineside::Parse<Lineside::ItemId>(idStr);
     }
   }
 }

--- a/liblineside/test/itemidtests.cpp
+++ b/liblineside/test/itemidtests.cpp
@@ -279,6 +279,28 @@ BOOST_AUTO_TEST_CASE(SmokeGoldenValues)
   }
 }
 
+BOOST_AUTO_TEST_CASE(StaticParse)
+{
+  std::map<Lineside::ItemId::IdType,std::string> gv;
+  gv[145875] = "00:02:39:d3";
+  gv[1234553784] = "49:95:cb:b8";
+  gv[4294967295] = "ff:ff:ff:ff";
+  gv[4278190081] = "ff:00:00:01";
+  gv[2341] = "00:00:09:25";
+  gv[12419] = "00:00:30:83";
+  gv[345629] = "00:05:46:1d";
+  gv[125688] = "00:01:ea:f8";
+  gv[445337500] = "1a:8b:4f:9c";
+  
+  for( auto it=gv.begin(); it !=gv.end(); ++it ) {
+    Lineside::ItemId expected(it->first);
+
+    auto id = Lineside::Parse<Lineside::ItemId>(it->second);
+    
+    BOOST_CHECK_EQUAL(expected, id);
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/liblineside/test/xml/configurationreadertests.cpp
+++ b/liblineside/test/xml/configurationreadertests.cpp
@@ -47,8 +47,7 @@ BOOST_AUTO_TEST_CASE( SmokeReader )
   auto item0 = res.pwItems.at(0);
   auto tcmd0 = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitorData>(item0);
   BOOST_REQUIRE( tcmd0 );
-  Lineside::ItemId expectedId;
-  expectedId.Parse("10:fe:02:1a");
+  auto expectedId = Lineside::Parse<Lineside::ItemId>("10:fe:02:1a");
   BOOST_CHECK_EQUAL( tcmd0->id, expectedId );
   BOOST_CHECK_EQUAL( tcmd0->inputPinRequest.controller, "GPIO" );
   BOOST_CHECK_EQUAL( tcmd0->inputPinRequest.controllerData, "07" );
@@ -77,8 +76,7 @@ BOOST_AUTO_TEST_CASE( ReadTwoTCM )
   BOOST_CHECK_EQUAL( res.hwManager.settings.at("hwA"), "hwB" );
 
   // Check the list of PWItems
-  Lineside::ItemId expectedId;
-  expectedId.Parse("00:ff:00:aa");
+  auto expectedId = Lineside::Parse<Lineside::ItemId>("00:ff:00:aa");
   BOOST_REQUIRE_EQUAL( res.pwItems.size(), 2 );
   for( size_t i=0; i<2; ++i ) {
     auto tcmd = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitorData>(res.pwItems.at(i));

--- a/liblineside/test/xml/pwitemdatareadertests.cpp
+++ b/liblineside/test/xml/pwitemdatareadertests.cpp
@@ -47,8 +47,7 @@ BOOST_AUTO_TEST_CASE( SmokeServoTurnoutMotorData )
   auto result = reader.Read(servoTurnoutMotorElement);
   BOOST_REQUIRE(result);
 
-  Lineside::ItemId expectedId;
-  expectedId.Parse("00:fe:1a:af");
+  auto expectedId = Lineside::Parse<Lineside::ItemId>("00:fe:1a:af");
   BOOST_CHECK_EQUAL( result->id, expectedId );
 
   auto stmd = std::dynamic_pointer_cast<Lineside::ServoTurnoutMotorData>(result);
@@ -77,8 +76,7 @@ BOOST_AUTO_TEST_CASE( SmokeTrackCircuitMonitorData )
   auto result = reader.Read(tcmElement);
   BOOST_REQUIRE(result);
 
-  Lineside::ItemId expectedId;
-  expectedId.Parse("00:ff:00:aa");
+  auto expectedId = Lineside::Parse<Lineside::ItemId>("00:ff:00:aa");
   BOOST_CHECK_EQUAL( result->id, expectedId );
 
   auto tcmd = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitorData>(result);
@@ -106,8 +104,7 @@ BOOST_AUTO_TEST_CASE( SmokeMultiaspectSignalHeadData )
   auto result = reader.Read(mashElement);
   BOOST_REQUIRE(result);
 
-  Lineside::ItemId expectedId;
-  expectedId.Parse("00:1a:2b:3c");
+  auto expectedId = Lineside::Parse<Lineside::ItemId>("00:1a:2b:3c");
   BOOST_CHECK_EQUAL( result->id, expectedId );
 
   auto mashd = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHeadData>(result);

--- a/liblineside/test/xml/pwitemlistreadertests.cpp
+++ b/liblineside/test/xml/pwitemlistreadertests.cpp
@@ -43,20 +43,17 @@ BOOST_AUTO_TEST_CASE( SmokePWItemListReader )
 
   auto tcmd = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitorData>(pwItems.at(0));
   BOOST_REQUIRE( tcmd );
-  Lineside::ItemId tcmId;
-  tcmId.Parse("00:fe:00:1a");
+  auto tcmId = Lineside::Parse<Lineside::ItemId>("00:fe:00:1a");
   BOOST_CHECK_EQUAL( tcmd->id, tcmId );
 
   auto mashd = std::dynamic_pointer_cast<Lineside::MultiAspectSignalHeadData>(pwItems.at(1));
   BOOST_REQUIRE( mashd );
-  Lineside::ItemId mashId;
-  mashId.Parse("00:1f:2e:3d");
+  auto mashId = Lineside::Parse<Lineside::ItemId>("00:1f:2e:3d");
   BOOST_CHECK_EQUAL( mashd->id, mashId );
 
   auto stmd = std::dynamic_pointer_cast<Lineside::ServoTurnoutMotorData>(pwItems.at(2));
   BOOST_REQUIRE( stmd );
-  Lineside::ItemId stmId;
-  stmId.Parse("00:0e:2a:5f");
+  auto stmId = Lineside::Parse<Lineside::ItemId>("00:0e:2a:5f");
   BOOST_CHECK_EQUAL( stmd->id, stmId );
 }
 
@@ -76,11 +73,8 @@ BOOST_AUTO_TEST_CASE( TwoTrackCircuitMonitors )
   BOOST_REQUIRE_EQUAL( pwItems.size(), 2 );
 
   std::vector<Lineside::ItemId> expectedIds;
-  Lineside::ItemId id;
-  id.Parse("00:fe:00:1a");
-  expectedIds.push_back(id);
-  id.Parse("00:fe:00:00");
-  expectedIds.push_back(id);
+  expectedIds.push_back(Lineside::Parse<Lineside::ItemId>("00:fe:00:1a"));
+  expectedIds.push_back(Lineside::Parse<Lineside::ItemId>("00:fe:00:00"));
   for( size_t i=0; i<pwItems.size(); i++ ) {
     auto tcmd = std::dynamic_pointer_cast<Lineside::TrackCircuitMonitorData>(pwItems.at(i));
     BOOST_REQUIRE( tcmd );


### PR DESCRIPTION
Add a template specialisation for `Lineside::Parse<>` for the `ItemId` type, so that strings can be parsed directly without having to create an `ItemId` object first (trying to create a static `ItemId::Parse()` method fails due to the member method with the same signature). Insert this new function into relevant places.