### PR TITLE
Connect up Cabinet Service

### DIFF
--- a/apps/cabinet/CMakeLists.txt
+++ b/apps/cabinet/CMakeLists.txt
@@ -7,3 +7,5 @@ list(APPEND srcs stubsoftwaremanager.cpp)
 add_executable(LinesideCabinet ${srcs})
 
 target_link_libraries(LinesideCabinet PUBLIC lineside Boost::program_options)
+
+configure_file(sample-configuration.xml . COPYONLY)

--- a/apps/cabinet/CMakeLists.txt
+++ b/apps/cabinet/CMakeLists.txt
@@ -1,7 +1,9 @@
 set(srcs)
 
 list(APPEND srcs main.cpp)
+list(APPEND srcs cmdlineopts.cpp)
+list(APPEND srcs stubsoftwaremanager.cpp)
 
 add_executable(LinesideCabinet ${srcs})
 
-target_link_libraries(LinesideCabinet PUBLIC lineside)
+target_link_libraries(LinesideCabinet PUBLIC lineside Boost::program_options)

--- a/apps/cabinet/cmdlineopts.cpp
+++ b/apps/cabinet/cmdlineopts.cpp
@@ -1,0 +1,38 @@
+#include <iostream>
+#include <boost/program_options.hpp>
+
+#include "cmdlineopts.hpp"
+
+namespace bpo = boost::program_options;
+
+void CmdLineOpts::Populate(int argc, char* argv[]) {
+  const std::string configOpt = "configuration-file";
+  const char configOptSingle = 'f';
+  const std::string configOptDesc = "Path to configuration XML file";
+
+  const std::string configOptSpec = configOpt + "," + configOptSingle;
+
+  bpo::options_description desc("Allowed Options");
+  desc.add_options()
+    ("help", "Show help message")
+    (configOptSpec.c_str(), bpo::value<std::string>(&(this->configFilePath)), configOptDesc.c_str())
+    ;
+  
+  bpo::variables_map vm;
+  bpo::store(bpo::parse_command_line(argc, argv, desc), vm);
+  bpo::notify(vm);
+  
+  if( vm.count("help") ) {
+    std::cout << desc << std::endl;
+    this->helpMessagePrinted = true;
+    return;
+  }
+
+  if( vm.count(configOpt.c_str()) ) {
+    std::cout << "Configuration file: " << this->configFilePath << std::endl;
+  } else {
+    throw std::runtime_error("Configuration file not specified");
+  }
+
+}
+

--- a/apps/cabinet/cmdlineopts.hpp
+++ b/apps/cabinet/cmdlineopts.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+class CmdLineOpts {
+public:
+  CmdLineOpts() :
+    helpMessagePrinted(false),
+    configFilePath() {}
+
+  bool helpMessagePrinted;
+  std::string configFilePath;
+
+  void Populate(int argc, char* argv[]);
+};

--- a/apps/cabinet/sample-configuration.xml
+++ b/apps/cabinet/sample-configuration.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<LinesideCabinet>
+  <SoftwareManager>
+    <RTC address="addr" port="8081" />
+    <Settings>
+      <Setting key="aKey" value="bValue" />
+    </Settings>
+  </SoftwareManager>
+  <HardwareManager>
+    <I2CDevices />
+    <Settings />
+  </HardwareManager>
+  <!-- Start of the item list -->
+  <PermanentWayItems>
+    <!-- Comment -->
+    <TrackCircuitMonitor id="00:ff:00:aa">
+      <BinaryInput controller="GPIO" controllerData="17">
+	<Settings>
+          <Setting key="glitch" value="300000" />
+	  <Setting key="pud" value="Down" />
+	</Settings>
+      </BinaryInput>
+    </TrackCircuitMonitor>
+    <!-- Comment -->
+    <TrackCircuitMonitor id="ff:00:00:11">
+      <BinaryInput controller="GPIO" controllerData="22">
+	<Settings>
+          <Setting key="glitch" value="300000" />
+	  <Setting key="pud" value="Down" />
+	</Settings>
+      </BinaryInput>
+    </TrackCircuitMonitor>
+    <!-- Comment -->
+    <MultiAspectSignalHead id="00:1a:2b:3c">
+      <Aspect name="Red">
+        <BinaryOutput controller="GPIO" controllerData="19" />
+      </Aspect>
+      <Aspect name="Yellow1">
+        <BinaryOutput controller="GPIO" controllerData="26" />
+      </Aspect>
+      <Aspect name="Green">
+        <BinaryOutput controller="GPIO" controllerData="06" />
+      </Aspect>
+      <Feather route="1">
+        <BinaryOutput controller="GPIO" controllerData="05" />
+      </Feather>
+    </MultiAspectSignalHead>
+  </PermanentWayItems>
+</LinesideCabinet>

--- a/apps/cabinet/stubsoftwaremanager.cpp
+++ b/apps/cabinet/stubsoftwaremanager.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+
+#include "stubsoftwaremanager.hpp"
+
+void StubRTCClient::SendTrackCircuitNotification(const Lineside::ItemId trackCircuitId,
+						 const bool occupied ) {
+  std::cout << __FUNCTION__ << ": "
+	    << trackCircuitId << " "
+	    << occupied << std::endl;
+}
+
+std::shared_ptr<Lineside::RTCClient> StubSoftwareManager::GetRTCClient() {
+  auto result = std::make_shared<StubRTCClient>();
+
+  this->rtcClientList.push_back(result);
+
+  return result;
+}

--- a/apps/cabinet/stubsoftwaremanager.hpp
+++ b/apps/cabinet/stubsoftwaremanager.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "lineside/rtcclient.hpp"
+#include "lineside/softwaremanager.hpp"
+
+class StubRTCClient : public Lineside::RTCClient {
+public:
+  StubRTCClient() : RTCClient() {}
+  
+  virtual void SendTrackCircuitNotification(const Lineside::ItemId trackCircuitId,
+					    const bool occupied ) override;
+};
+
+class StubSoftwareManager : public Lineside::SoftwareManager {
+public:
+  StubSoftwareManager() :
+    SoftwareManager(),
+    rtcClientList() {}
+  
+  virtual std::shared_ptr<Lineside::RTCClient> GetRTCClient() override;
+  
+  std::vector<std::shared_ptr<StubRTCClient>> rtcClientList;
+};

--- a/liblineside/include/lineside/jsonrpc/cabinetserviceimpl.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetserviceimpl.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include "lineside/pwitemmanager.hpp"
+
 #include "lineside/jsonrpc/cabinetservice.hpp"
 
 namespace Lineside {
@@ -7,7 +10,7 @@ namespace Lineside {
     //! Implementation of the CabinetService
     class CabinetServiceImpl : public CabinetService {
     public:
-      CabinetServiceImpl();
+      CabinetServiceImpl(std::shared_ptr<const PWItemManager> itemManager);
 
       virtual
       CabinetServiceResponse
@@ -36,6 +39,9 @@ namespace Lineside {
       virtual bool GetTrackCircuit(const Lineside::ItemId id) override;
 
       virtual bool GetTrackCircuitString(const std::string id) override;
+
+    private:
+      std::shared_ptr<const PWItemManager> pwim;
     };
   }
 }

--- a/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
+++ b/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 
 #include "lineside/multiaspectsignalhead.hpp"
+#include "lineside/turnoutmotor.hpp"
+#include "lineside/trackcircuitmonitor.hpp"
 
 #include "lineside/jsonrpc/cabinetserviceimpl.hpp"
 
@@ -20,13 +22,9 @@ namespace Lineside {
 		<< state << " "
 		<< flash << " "
 		<< feather << std::endl;
-      auto item = &(this->pwim->GetPWItemModelById(id));
-      auto mash = dynamic_cast<Lineside::MultiAspectSignalHead*>(item);
-      if( mash ) {
-	mash->SetState(state, flash, feather);
-      } else {
-	throw std::logic_error("Not a MultiAspectSignalHead" + id.ToString());
-      }
+      Lineside::PWItemModel& item = this->pwim->GetPWItemModelById(id);
+      Lineside::MultiAspectSignalHead& mash = dynamic_cast<Lineside::MultiAspectSignalHead&>(item);
+      mash.SetState(state, flash, feather);
       return CabinetServiceResponse::Success;
     }
 
@@ -47,7 +45,9 @@ namespace Lineside {
       std::cout << __FUNCTION__ << ": "
 		<< id << " "
 		<< state << std::endl;
-      
+      Lineside::PWItemModel& item = this->pwim->GetPWItemModelById(id);
+      Lineside::TurnoutMotor& turnout = dynamic_cast<Lineside::TurnoutMotor&>(item);
+      turnout.SetState(state);
       return CabinetServiceResponse::Success;
     }
 
@@ -62,7 +62,9 @@ namespace Lineside {
     bool CabinetServiceImpl::GetTrackCircuit(const Lineside::ItemId id) {
       std::cout << __FUNCTION__ << ": "
 		<< id << std::endl;
-      return true;
+      Lineside::PWItemModel& item = this->pwim->GetPWItemModelById(id);
+      Lineside::TrackCircuitMonitor& tcm = dynamic_cast<Lineside::TrackCircuitMonitor&>(item);
+      return tcm.GetState();
     }
 
     bool CabinetServiceImpl::GetTrackCircuitString(const std::string id) {

--- a/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
+++ b/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
@@ -1,10 +1,14 @@
 #include <iostream>
+
+#include "lineside/multiaspectsignalhead.hpp"
+
 #include "lineside/jsonrpc/cabinetserviceimpl.hpp"
 
 namespace Lineside {
   namespace JsonRPC {
     
-    CabinetServiceImpl::CabinetServiceImpl() {}
+    CabinetServiceImpl::CabinetServiceImpl(std::shared_ptr<const PWItemManager> itemManager)
+      : pwim(itemManager) {}
       
     CabinetServiceResponse
     CabinetServiceImpl::SetMultiAspectSignal(const Lineside::ItemId id,
@@ -16,6 +20,13 @@ namespace Lineside {
 		<< state << " "
 		<< flash << " "
 		<< feather << std::endl;
+      auto item = &(this->pwim->GetPWItemModelById(id));
+      auto mash = dynamic_cast<Lineside::MultiAspectSignalHead*>(item);
+      if( mash ) {
+	mash->SetState(state, flash, feather);
+      } else {
+	throw std::logic_error("Not a MultiAspectSignalHead" + id.ToString());
+      }
       return CabinetServiceResponse::Success;
     }
 


### PR DESCRIPTION
Update the implementation of the `CabinetService` so that it performs the indicated actions. Also update the `LinesideCabinet` app to set up properly. This has only been subject to manual tests so far.