### PR TITLE
Bugfix for GetSingleElementByName

### DIFF
--- a/liblineside/src/xml/hardwaremanagerdatareader.cpp
+++ b/liblineside/src/xml/hardwaremanagerdatareader.cpp
@@ -16,7 +16,8 @@ namespace Lineside {
       return HasChildElement(parent, this->HardwareManagerElement);
     }
 
-    xercesc::DOMElement* HardwareManagerDataReader::GetHardwareManagerElement( const xercesc::DOMElement *parent ) const {
+    xercesc::DOMElement*
+    HardwareManagerDataReader::GetHardwareManagerElement( const xercesc::DOMElement *parent ) const {
       if( !parent ) {
 	throw std::logic_error("Bad parent ptr");
       }
@@ -29,7 +30,8 @@ namespace Lineside {
       return hardwaremanagerElement;
     }
 
-    Lineside::HardwareManagerData HardwareManagerDataReader::Read( const xercesc::DOMElement *hardwaremanagerElement ) const {
+    Lineside::HardwareManagerData
+    HardwareManagerDataReader::Read( const xercesc::DOMElement *hardwaremanagerElement ) const {
       if( !hardwaremanagerElement ) {
 	throw std::logic_error("Bad hardwaremanagerElement ptr");
       }

--- a/liblineside/src/xml/utilities.cpp
+++ b/liblineside/src/xml/utilities.cpp
@@ -43,25 +43,27 @@ namespace Lineside {
 						 const std::string name ) {
       auto TAG_Name = StrToXMLCh(name);
 
-      auto elementList = parent->getElementsByTagName( TAG_Name.get() );
-      if( elementList == nullptr ) {
-	std::stringstream msg;
-	msg << "Failed getElementsByTagName call for " << name;
-	throw std::runtime_error(msg.str());
+      int resultCount = 0;
+      xercesc::DOMElement* result = nullptr;
+      
+      // We only want the direct children, so can't use getElementsByTagName
+      auto childList = parent->getChildNodes();
+      for( XMLSize_t i=0; i<childList->getLength(); i++ ) {
+	auto child = childList->item(i);
+	if( IsElementNode(child) ) {
+	  auto element = dynamic_cast<xercesc::DOMElement*>(child);
+
+	  if( xercesc::XMLString::equals( element->getTagName(), TAG_Name.get() )) {
+	    resultCount++;
+	    result = element;
+	  }
+	}
       }
       
-      if( elementList->getLength() != 1 ) {
+      if( resultCount != 1 ) {
 	std::stringstream msg;
-	msg << "Did not find exactly one child element " << name;
-	throw std::runtime_error(msg.str());
-      }
-      
-      auto result = dynamic_cast<xercesc::DOMElement*>(elementList->item(0));
-      if( result == nullptr ) {
-	std::stringstream msg;
-	msg << "Failed to obtain item "
-	    << name
-	    << " from elementList";
+	msg << "Did not find exactly one child element " << name
+	    << " in element " << XMLChToStr(parent->getTagName());
 	throw std::runtime_error(msg.str());
       }
       

--- a/liblineside/test/xml/hardwaremanagerdatareadertests.cpp
+++ b/liblineside/test/xml/hardwaremanagerdatareadertests.cpp
@@ -40,7 +40,9 @@ BOOST_AUTO_TEST_CASE( SmokeReader )
   BOOST_CHECK_EQUAL( dev0.bus, 0 );
   BOOST_CHECK_EQUAL( dev0.address, 0xFF );
   BOOST_CHECK_EQUAL( dev0.name, "pwm0" );
-
+  BOOST_REQUIRE_EQUAL( dev0.settings.size(), 1 );
+  BOOST_CHECK_EQUAL( dev0.settings.at("key9685"), "val9685" );
+  
   BOOST_REQUIRE_EQUAL( result.settings.size(), 1 );
   BOOST_CHECK_EQUAL( result.settings.at("some"), "thing" );
 }

--- a/liblineside/test/xmlsamples/hardwaremanager-fragment.xml
+++ b/liblineside/test/xmlsamples/hardwaremanager-fragment.xml
@@ -2,7 +2,11 @@
 <Test>
   <HardwareManager>
     <I2CDevices>
-      <I2CDevice kind="pca9685" bus="0" address="0xFF" name="pwm0" />
+      <I2CDevice kind="pca9685" bus="0" address="0xFF" name="pwm0">
+	<Settings>
+	  <Setting key="key9685" value="val9685" />
+	</Settings>
+      </I2CDevice>
     </I2CDevices>
     <Settings>
       <Setting key="some" value="thing" />


### PR DESCRIPTION
The XML utility routine `GetSingleElementByName()` assumed that `getElementsByTagName()` only returned direct children. This ran into trouble with the `HardwareManagerData`. Change the internal workings to address this, along with a test which verifies that the data can be read correctly.