### PR TITLE
Update JSON-RPC service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 
 FetchContent_Declare(json
   GIT_REPOSITORY https://github.com/nlohmann/json.git
-  GIT_TAG v3.7.3)
+  GIT_TAG v3.9.1)
 
 FetchContent_GetProperties(json)
 if(NOT json_POPULATED)

--- a/apps/cabinet/sample-configuration.xml
+++ b/apps/cabinet/sample-configuration.xml
@@ -7,8 +7,15 @@
     </Settings>
   </SoftwareManager>
   <HardwareManager>
-    <I2CDevices />
-    <Settings />
+    <I2CDevices>
+      <I2CDevice kind="pca9685" bus="1" address="0x40" name="sc01">
+        <Settings>
+          <Setting key="referenceClock" value="25e6" />
+          <Setting key="pwmFrequency" value="50" />
+        </Settings>
+      </I2CDevice>
+    </I2CDevices>
+    <Settings/>
   </HardwareManager>
   <!-- Start of the item list -->
   <PermanentWayItems>
@@ -45,5 +52,9 @@
         <BinaryOutput controller="GPIO" controllerData="05" />
       </Feather>
     </MultiAspectSignalHead>
+    <!-- Another comment -->
+    <ServoTurnoutMotor id="00:aa:bb:cc" straight="200" curved="400" >
+      <PWMChannel controller="sc01" controllerData="00" />
+    </ServoTurnoutMotor>
   </PermanentWayItems>
 </LinesideCabinet>

--- a/liblineside/include/lineside/jsonrpc/cabinetservice.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetservice.hpp
@@ -24,43 +24,14 @@ namespace Lineside {
 			   const Lineside::SignalFlash flash,
 			   const unsigned int feather) = 0;
 
-      //! Function to set the state of a multiaspect signal
-      /*!
-	This is a dupicate with string arguments in case there are issues
-	with converting the custom types.
-       */
-      virtual
-      CabinetServiceResponse
-      SetMultiAspectSignalString(const std::string id,
-				 const std::string state,
-				 const std::string flash,
-				 const unsigned int feather) = 0;
-
       //! Function to set the state of a turnout
       virtual
       CabinetServiceResponse
       SetTurnout(const Lineside::ItemId id,
 		 const Lineside::TurnoutState state) = 0;
-      
-      //! Function to set the state of a turnout
-      /*!
-	This is a dupicate with string arguments in case there are issues
-	with converting the custom types.
-       */
-      virtual
-      CabinetServiceResponse
-      SetTurnoutString(const std::string id,
-		       const std::string state) = 0;
 
       //! Function to get the state of a track circuit
       virtual bool GetTrackCircuit(const Lineside::ItemId id) = 0;
-
-      //! Function to get the state of a track circuit
-      /*!
-	This is a dupicate with string arguments in case there are issues
-	with converting the custom types.
-       */
-      virtual bool GetTrackCircuitString(const std::string id) = 0;
     };
   }
 }

--- a/liblineside/include/lineside/jsonrpc/cabinetserviceimpl.hpp
+++ b/liblineside/include/lineside/jsonrpc/cabinetserviceimpl.hpp
@@ -18,28 +18,13 @@ namespace Lineside {
 			   const Lineside::SignalState state,
 			   const Lineside::SignalFlash flash,
 			   const unsigned int feather) override;
-      
-      virtual
-      CabinetServiceResponse
-      SetMultiAspectSignalString(const std::string id,
-				 const std::string state,
-				 const std::string flash,
-				 const unsigned int feather) override;
 
       virtual
       CabinetServiceResponse
       SetTurnout(const Lineside::ItemId id,
 		 const Lineside::TurnoutState state) override;
-      
-      virtual
-      CabinetServiceResponse
-      SetTurnoutString(const std::string id,
-		       const std::string state) override;
 
       virtual bool GetTrackCircuit(const Lineside::ItemId id) override;
-
-      virtual bool GetTrackCircuitString(const std::string id) override;
-
     private:
       std::shared_ptr<const PWItemManager> pwim;
     };

--- a/liblineside/include/lineside/jsonrpc/rpcserver.hpp
+++ b/liblineside/include/lineside/jsonrpc/rpcserver.hpp
@@ -5,6 +5,12 @@
 #include <jsonrpccxx/server.hpp>
 
 namespace Lineside {
+
+  //! Ensure that the RPC server knows that ItemId can be got from a string
+  constexpr nlohmann::json::value_t GetType(jsonrpccxx::type<ItemId>) {
+    return nlohmann::json::value_t::string;
+  }
+  
   namespace JsonRPC {
     class RPCServer {
     public:

--- a/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
+++ b/liblineside/src/jsonrpc/cabinetserviceimpl.cpp
@@ -29,17 +29,6 @@ namespace Lineside {
     }
 
     CabinetServiceResponse
-    CabinetServiceImpl::SetMultiAspectSignalString(const std::string id,
-						   const std::string state,
-						   const std::string flash,
-						   const unsigned int feather ) {
-      auto idObj = Lineside::Parse<ItemId>(id);
-      auto stateEnum = Lineside::Parse<Lineside::SignalState>(state);
-      auto flashEnum = Lineside::Parse<Lineside::SignalFlash>(flash);
-      return this->SetMultiAspectSignal(idObj, stateEnum, flashEnum, feather);
-    }
-
-    CabinetServiceResponse
     CabinetServiceImpl::SetTurnout(const Lineside::ItemId id,
 				   const Lineside::TurnoutState state) {
       std::cout << __FUNCTION__ << ": "
@@ -51,25 +40,12 @@ namespace Lineside {
       return CabinetServiceResponse::Success;
     }
 
-    CabinetServiceResponse
-    CabinetServiceImpl::SetTurnoutString(const std::string id,
-					 const std::string state) {
-      auto idObj = Lineside::Parse<ItemId>(id);
-      auto stateEnum = Lineside::Parse<Lineside::TurnoutState>(state);
-      return this->SetTurnout(idObj, stateEnum);
-    }
-
     bool CabinetServiceImpl::GetTrackCircuit(const Lineside::ItemId id) {
       std::cout << __FUNCTION__ << ": "
 		<< id << std::endl;
       Lineside::PWItemModel& item = this->pwim->GetPWItemModelById(id);
       Lineside::TrackCircuitMonitor& tcm = dynamic_cast<Lineside::TrackCircuitMonitor&>(item);
       return tcm.GetState();
-    }
-
-    bool CabinetServiceImpl::GetTrackCircuitString(const std::string id) {
-      auto idObj = Lineside::Parse<ItemId>(id);
-      return this->GetTrackCircuit(idObj);
     }
   }
 }

--- a/liblineside/src/jsonrpc/rpcserver.cpp
+++ b/liblineside/src/jsonrpc/rpcserver.cpp
@@ -10,7 +10,7 @@ namespace Lineside {
       rpcServer() {
       // Due to difficulties handling custom types, need to use 'String' versions
       this->rpcServer.Add("SetMultiAspectSignal",
-			  jsonrpccxx::GetHandle(&CabinetService::SetMultiAspectSignalString,
+			  jsonrpccxx::GetHandle(&CabinetService::SetMultiAspectSignal,
 						*(this->cabinet.get())),
 			  {"id", "state", "flash", "feather"});
       

--- a/liblineside/src/jsonrpc/rpcserver.cpp
+++ b/liblineside/src/jsonrpc/rpcserver.cpp
@@ -5,6 +5,7 @@
 
 namespace Lineside {
   namespace JsonRPC {
+    
     RPCServer::RPCServer(std::shared_ptr<CabinetService> cabinet) :
       cabinet(cabinet),
       rpcServer() {
@@ -15,12 +16,12 @@ namespace Lineside {
 			  {"id", "state", "flash", "feather"});
       
       this->rpcServer.Add("SetTurnout",
-			  jsonrpccxx::GetHandle(&CabinetService::SetTurnoutString,
+			  jsonrpccxx::GetHandle(&CabinetService::SetTurnout,
 						*(this->cabinet.get())),
 			  {"id", "state"});
       
       this->rpcServer.Add("GetTrackCircuit",
-			  jsonrpccxx::GetHandle(&CabinetService::GetTrackCircuitString,
+			  jsonrpccxx::GetHandle(&CabinetService::GetTrackCircuit,
 						*(this->cabinet.get())),
 			  {"id"});
     }


### PR DESCRIPTION
The library `json-rpc-cxx` has had an update to make it work with `enum class` types properly. Bring in update to the JSON library underlying the RPC server library. Also, add a type mapper for `ItemId`. With these in place, we no longer need the `CabinetService` 'string' methods.