### PR TITLE
Testing for DirectDriveMASH

### DIFF
--- a/liblineside/include/lineside/directdrivemash.hpp
+++ b/liblineside/include/lineside/directdrivemash.hpp
@@ -72,10 +72,6 @@ namespace Lineside {
 
     bool lastFlashStatus;
     
-    std::string buildStateString(const SignalState state,
-				 const SignalFlash flash,
-				 const unsigned int feather) const;
-    
     void turnAllOff();
 
     void setStateFromDesired();

--- a/liblineside/include/lineside/linesideexceptions.hpp
+++ b/liblineside/include/lineside/linesideexceptions.hpp
@@ -4,6 +4,8 @@
 #include <sstream>
 
 #include "lineside/itemid.hpp"
+#include "lineside/signalstate.hpp"
+#include "lineside/signalflash.hpp"
 
 namespace Lineside {
   //! Base class for all exceptions from this library
@@ -144,22 +146,28 @@ namespace Lineside {
 
   // ========================================
 
-  //! Exception for attempts to place PWItem into invalid state
-  class InvalidStateException : public LinesideException {
+  //! Exception for attempts set a bad state on a MultiAspectSignalHead
+  class InvalidMASHStateException : public LinesideException {
   public:
-    explicit InvalidStateException(const ItemId targetItem, const std::string stateInfo) :
+    explicit InvalidMASHStateException(const ItemId targetItem,
+				       const SignalState state,
+				       const SignalFlash flash,
+				       const unsigned int feather) :
       LinesideException(""),
       target(targetItem),
-      info(stateInfo),
+      state(state),
+      flash(flash),
+      feather(feather),
       message() {
       std::stringstream tmp;
-      tmp << "Invalid state for " << this->target << ".";
-      tmp << " State was: " << this->info;
+      tmp << "Invalid state for " << this->target;
       this->message = tmp.str();
     }
     
     const ItemId target;
-    const std::string info;
+    const SignalState state;
+    const SignalFlash flash;
+    const unsigned int feather;
     std::string message;
 
     virtual const char* what() const noexcept override {

--- a/liblineside/include/lineside/linesideexceptions.hpp
+++ b/liblineside/include/lineside/linesideexceptions.hpp
@@ -160,7 +160,12 @@ namespace Lineside {
       feather(feather),
       message() {
       std::stringstream tmp;
-      tmp << "Invalid state for " << this->target;
+      tmp << "Invalid state for " << this->target << ". ";
+      tmp << "State was: "
+	  <<  "{"
+	  << state << ","
+	  << flash << ","
+	  << feather << "}";
       this->message = tmp.str();
     }
     

--- a/liblineside/src/directdrivemash.cpp
+++ b/liblineside/src/directdrivemash.cpp
@@ -38,29 +38,29 @@ namespace Lineside {
   }
 
   void DirectDriveMASH::SetState(const SignalState wantedState,
-				       const SignalFlash wantedFlash,
-				       const unsigned int wantedFeather ) {
+				 const SignalFlash wantedFlash,
+				 const unsigned int wantedFeather ) {
     std::lock_guard<std::mutex> lockState(this->stateChangeMtx);
     
     // Checks on the aspects
     if( wantedState == SignalState::Yellow ) {
       if( !this->yellow1 ) {
 	auto stateString = this->buildStateString(wantedState, wantedFlash, wantedFeather);
-	throw InvalidStateException(this->getId(), stateString);
+	throw InvalidMASHStateException(this->getId(), wantedState, wantedFlash, wantedFeather);
       }
     }
 
     if( wantedState == SignalState::DoubleYellow ) {
       if( !this->yellow2 ) {
 	auto stateString = this->buildStateString(wantedState, wantedFlash, wantedFeather);
-	throw InvalidStateException(this->getId(), stateString);
+	throw InvalidMASHStateException(this->getId(), wantedState, wantedFlash, wantedFeather);
       }
     }
 
     // Check on the feather
     if( wantedFeather > this->feathers.size() ) {
       auto stateString = this->buildStateString(wantedState, wantedFlash, wantedFeather);
-      throw InvalidStateException(this->getId(), stateString);
+      throw InvalidMASHStateException(this->getId(), wantedState, wantedFlash, wantedFeather);
     }
 
     this->lastFlashStatus = true; // Make sure flashing starts with aspect on

--- a/liblineside/src/directdrivemash.cpp
+++ b/liblineside/src/directdrivemash.cpp
@@ -45,21 +45,18 @@ namespace Lineside {
     // Checks on the aspects
     if( wantedState == SignalState::Yellow ) {
       if( !this->yellow1 ) {
-	auto stateString = this->buildStateString(wantedState, wantedFlash, wantedFeather);
 	throw InvalidMASHStateException(this->getId(), wantedState, wantedFlash, wantedFeather);
       }
     }
 
     if( wantedState == SignalState::DoubleYellow ) {
       if( !this->yellow2 ) {
-	auto stateString = this->buildStateString(wantedState, wantedFlash, wantedFeather);
 	throw InvalidMASHStateException(this->getId(), wantedState, wantedFlash, wantedFeather);
       }
     }
 
     // Check on the feather
     if( wantedFeather > this->feathers.size() ) {
-      auto stateString = this->buildStateString(wantedState, wantedFlash, wantedFeather);
       throw InvalidMASHStateException(this->getId(), wantedState, wantedFlash, wantedFeather);
     }
 
@@ -68,17 +65,6 @@ namespace Lineside {
     this->desiredFlash = wantedFlash;
     this->desiredFeather = wantedFeather;
     this->WakeController();
-  }
-
-  std::string DirectDriveMASH::buildStateString(const SignalState state,
-						const SignalFlash flash,
-						const unsigned int feather) const {
-    std::stringstream result;
-    result << "{"
-	   << state << ","
-	   << flash << ","
-	   << feather << "}";
-    return result.str();
   }
   
   void DirectDriveMASH::turnAllOff() {

--- a/liblineside/test/exceptiontests.cpp
+++ b/liblineside/test/exceptiontests.cpp
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(InvalidMASHStateException)
   BOOST_CHECK_EQUAL( ise.flash, Lineside::SignalFlash::Steady );
   BOOST_CHECK_EQUAL( ise.feather, 1 );
 
-  const std::string expected = "Invalid state for 00:00:01:00. State was: (DoubleYellow, Steady, 1)";
+  const std::string expected = "Invalid state for 00:00:01:00. State was: {DoubleYellow,Steady,1}";
   BOOST_CHECK_EQUAL( ise.what(), expected );
 }
 

--- a/liblineside/test/exceptiontests.cpp
+++ b/liblineside/test/exceptiontests.cpp
@@ -62,16 +62,20 @@ BOOST_AUTO_TEST_CASE(DuplicateKeyException)
   BOOST_CHECK_EQUAL(expected, dke.what());
 }
 
-BOOST_AUTO_TEST_CASE(InvalidStateException)
+BOOST_AUTO_TEST_CASE(InvalidMASHStateException)
 {
   const Lineside::ItemId id(256);
-  const std::string stateInfo("Something or other");
 
-  Lineside::InvalidStateException ise( id, stateInfo );
+  Lineside::InvalidMASHStateException ise( id,
+					   Lineside::SignalState::DoubleYellow,
+					   Lineside::SignalFlash::Steady,
+					   1 );
   BOOST_CHECK_EQUAL( ise.target, id );
-  BOOST_CHECK_EQUAL( ise.info, stateInfo );
+  BOOST_CHECK_EQUAL( ise.state, Lineside::SignalState::DoubleYellow );
+  BOOST_CHECK_EQUAL( ise.flash, Lineside::SignalFlash::Steady );
+  BOOST_CHECK_EQUAL( ise.feather, 1 );
 
-  const std::string expected = "Invalid state for 00:00:01:00. State was: Something or other";
+  const std::string expected = "Invalid state for 00:00:01:00. State was: (DoubleYellow, Steady, 1)";
   BOOST_CHECK_EQUAL( ise.what(), expected );
 }
 


### PR DESCRIPTION
Restore the 'bad state request' tests for the `DirectDriveMASH`. As part of this, change the `InvalidStateException` to `InvalidMASHStateException` since only multiple aspect signals throw this exception.