### PR TITLE
Make MaximumWaitSeconds configurable for the PWItemController

### DIFF
--- a/liblineside/include/lineside/pwitemcontroller.hpp
+++ b/liblineside/include/lineside/pwitemcontroller.hpp
@@ -21,6 +21,9 @@ namespace Lineside {
    */
   class PWItemController : public Notifiable<bool> {
   public:
+    //! Default value for the maximum interval between OnRun method calls
+    static constexpr std::chrono::seconds DefaultMaximumWaitSeconds = std::chrono::seconds(120);
+    
     virtual ~PWItemController();
 
     //! Start up the managing thread and use it to run the model
@@ -37,10 +40,11 @@ namespace Lineside {
 
     //! Create a PWItemController for the supplied model
     static std::shared_ptr<PWItemController> Construct(std::shared_ptr<PWItemModel> pwim);
-    
+
+    //! The maximum number of seconds before the OnRun method will be called again
+    static std::chrono::seconds MaximumWaitSeconds;
   private:
     enum class ControllerState { Constructed, Active, Inactive };
-    const std::chrono::seconds MaximumWaitSeconds = std::chrono::seconds(120);
     
     std::shared_ptr<PWItemModel> model;
     ItemId id;

--- a/liblineside/include/lineside/pwitemcontroller.hpp
+++ b/liblineside/include/lineside/pwitemcontroller.hpp
@@ -18,6 +18,10 @@ namespace Lineside {
     on the permanent way (such as a multiaspect signal head or a track circuit).
     The state of the item itself is the responsibility of the corresponding
     PWItemModel object.
+
+    This class will call the OnActivate, OnDeactivate and OnRun methods of the
+    PWItemModel object it is managing. The OnRun method returns a requested sleep
+    time, but the PWItemController will cap this at MaximumWaitSeconds.
    */
   class PWItemController : public Notifiable<bool> {
   public:

--- a/liblineside/src/pwitemcontroller.cpp
+++ b/liblineside/src/pwitemcontroller.cpp
@@ -9,7 +9,10 @@
 #include "lineside/pwitemcontroller.hpp"
 
 namespace Lineside {
-  std::shared_ptr<PWItemController> PWItemController::Construct(std::shared_ptr<PWItemModel> pwim) {
+  std::chrono::seconds PWItemController::MaximumWaitSeconds = PWItemController::DefaultMaximumWaitSeconds;
+  
+  std::shared_ptr<PWItemController>
+  PWItemController::Construct(std::shared_ptr<PWItemModel> pwim) {
     std::shared_ptr<PWItemController> result;
 
     // Work around the private constructor of PWItemController

--- a/liblineside/test/pwitemcontrollertests.cpp
+++ b/liblineside/test/pwitemcontrollertests.cpp
@@ -132,9 +132,12 @@ BOOST_AUTO_TEST_CASE(ShortDurationSleeps, *boost::unit_test::timeout(2))
 }
 
 BOOST_AUTO_TEST_CASE(LongSleepIgnored,
-		     *boost::unit_test::timeout(600)
+		     *boost::unit_test::timeout(40)
 		     *boost::unit_test::label("LongRunning"))
 {
+  // Shorten the maximum for easier testing
+  Lineside::PWItemController::MaximumWaitSeconds = std::chrono::seconds(10);
+  
   Lineside::ItemId id = Lineside::ItemId::Random();
   auto model = std::make_shared<MockModel>(id);
   auto controller = Lineside::PWItemController::Construct(model);
@@ -144,7 +147,7 @@ BOOST_AUTO_TEST_CASE(LongSleepIgnored,
   model->onRunWait = std::chrono::seconds(550);
 
   controller->Activate();
-  std::this_thread::sleep_for(std::chrono::seconds(400));
+  std::this_thread::sleep_for(std::chrono::seconds(35));
 
   // Should get at least three OnRun() calls due to MaximumWaitTime
   BOOST_CHECK_GE( model->onRunCallTimes.size(), 3 );


### PR DESCRIPTION
Turn `PWItemController::MaximumWaitSeconds` into a configurable static. This is mainly to allow the tests to run faster, without a large `sleep()` to allow a separate thread to run.