### PR TITLE
Filters for code coverage

### DIFF
--- a/azuredevops/Code-Coverage.yml
+++ b/azuredevops/Code-Coverage.yml
@@ -48,7 +48,7 @@ jobs:
     displayName: "Create directory for detailed code coverage results"
     workingDirectory: $(buildDir)
   
-  - script: gcovr --root $(Build.SourcesDirectory) . --xml cobetura.xml --html-details html/details.html --print-summary --exclude 'apps/'
+  - script: gcovr --root $(Build.SourcesDirectory) . --xml cobetura.xml --html-details html/details.html --print-summary --exclude 'apps/' --verbose
     displayName: "Run gcovr"
     workingDirectory: $(buildDir)
 

--- a/azuredevops/Code-Coverage.yml
+++ b/azuredevops/Code-Coverage.yml
@@ -48,7 +48,7 @@ jobs:
     displayName: "Create directory for detailed code coverage results"
     workingDirectory: $(buildDir)
   
-  - script: gcovr --root $(Build.SourcesDirectory) . --xml cobetura.xml --html-details html/details.html --print-summary --exclude 'apps/' --exclude 'lib.+/test/' --verbose
+  - script: gcovr --root $(Build.SourcesDirectory) . --xml cobetura.xml --html-details html/details.html --print-summary --exclude '$(Build.SourcesDirectory)/apps/' --exclude '$(Build.SourcesDirectory)/lib.+/test/' --verbose
     displayName: "Run gcovr"
     workingDirectory: $(buildDir)
 

--- a/azuredevops/Code-Coverage.yml
+++ b/azuredevops/Code-Coverage.yml
@@ -48,7 +48,7 @@ jobs:
     displayName: "Create directory for detailed code coverage results"
     workingDirectory: $(buildDir)
   
-  - script: gcovr --root $(Build.SourcesDirectory) . --xml cobetura.xml --html-details html/details.html --print-summary --exclude 'apps/' --verbose
+  - script: gcovr --root $(Build.SourcesDirectory) . --xml cobetura.xml --html-details html/details.html --print-summary --exclude 'apps/' --exclude 'lib+*/test/' --verbose
     displayName: "Run gcovr"
     workingDirectory: $(buildDir)
 

--- a/azuredevops/Code-Coverage.yml
+++ b/azuredevops/Code-Coverage.yml
@@ -48,7 +48,7 @@ jobs:
     displayName: "Create directory for detailed code coverage results"
     workingDirectory: $(buildDir)
   
-  - script: gcovr --root $(Build.SourcesDirectory) . --xml cobetura.xml --html-details html/details.html --print-summary --exclude apps/
+  - script: gcovr --root $(Build.SourcesDirectory) . --xml cobetura.xml --html-details html/details.html --print-summary --exclude 'apps/'
     displayName: "Run gcovr"
     workingDirectory: $(buildDir)
 

--- a/azuredevops/Code-Coverage.yml
+++ b/azuredevops/Code-Coverage.yml
@@ -48,7 +48,7 @@ jobs:
     displayName: "Create directory for detailed code coverage results"
     workingDirectory: $(buildDir)
   
-  - script: gcovr --root $(Build.SourcesDirectory) . --xml cobetura.xml --html-details html/details.html --print-summary --exclude 'apps/' --exclude 'lib/test/' --verbose
+  - script: gcovr --root $(Build.SourcesDirectory) . --xml cobetura.xml --html-details html/details.html --print-summary --exclude 'apps/' --exclude 'lib.+/test/' --verbose
     displayName: "Run gcovr"
     workingDirectory: $(buildDir)
 

--- a/azuredevops/Code-Coverage.yml
+++ b/azuredevops/Code-Coverage.yml
@@ -48,7 +48,7 @@ jobs:
     displayName: "Create directory for detailed code coverage results"
     workingDirectory: $(buildDir)
   
-  - script: gcovr --root $(Build.SourcesDirectory) . --xml cobetura.xml --html-details html/details.html --print-summary --exclude 'apps/' --exclude 'lib+*/test/' --verbose
+  - script: gcovr --root $(Build.SourcesDirectory) . --xml cobetura.xml --html-details html/details.html --print-summary --exclude 'apps/' --exclude 'lib/test/' --verbose
     displayName: "Run gcovr"
     workingDirectory: $(buildDir)
 

--- a/azuredevops/Code-Coverage.yml
+++ b/azuredevops/Code-Coverage.yml
@@ -48,7 +48,7 @@ jobs:
     displayName: "Create directory for detailed code coverage results"
     workingDirectory: $(buildDir)
   
-  - script: gcovr --root $(Build.SourcesDirectory) . --xml cobetura.xml --html-details html/details.html --print-summary
+  - script: gcovr --root $(Build.SourcesDirectory) . --xml cobetura.xml --html-details html/details.html --print-summary --exclude apps/
     displayName: "Run gcovr"
     workingDirectory: $(buildDir)
 


### PR DESCRIPTION
Exclude the `apps/` directory and all the `test/` directories from code coverage.