### PR TITLE
Make hardware private in MASH

### DIFF
--- a/liblineside/include/lineside/boparraymash.hpp
+++ b/liblineside/include/lineside/boparraymash.hpp
@@ -8,6 +8,8 @@
 #include "lineside/multiaspectsignalhead.hpp"
 
 namespace Lineside {
+  class BOPArrayMASHData;
+  
   //! Implementation of a multiple aspect signal head using a BOPArray
   class BOPArrayMASH : public MultiAspectSignalHead {
   public:
@@ -26,13 +28,8 @@ namespace Lineside {
     virtual unsigned int GetAspectCount() const override;
 
     virtual unsigned int GetFeatherCount() const override;
-
-    /*
-      Technically, the following ought to be private.
-      However, doing that makes testing a lot more difficult
-      and objects like this should be managed through
-      the parent classes anyway
-     */
+  private:
+    friend class BOPArrayMASHData;
     
     //! Access to the hardware
     std::unique_ptr<Tendril::BOPArray> pins;
@@ -49,7 +46,7 @@ namespace Lineside {
       will fail.
     */
     std::vector<unsigned int> feathers;
-  private:
+    
     //! Mark all pins for off (but don't Update)
     void markAllOff();
 

--- a/liblineside/include/lineside/directdrivemash.hpp
+++ b/liblineside/include/lineside/directdrivemash.hpp
@@ -30,11 +30,8 @@ namespace Lineside {
     virtual unsigned int GetAspectCount() const override;
 
     virtual unsigned int GetFeatherCount() const override;
-    
-    // One can argue that the following should be private
-    // However, this class should usually only be accessed through
-    // MultiAspectSignalHead, and making them private makes
-    // testing much harder
+  private:
+    friend class DirectDriveMASHData;
     
     std::unique_ptr<Tendril::BinaryOutputPin> red;
     std::unique_ptr<Tendril::BinaryOutputPin> yellow1;
@@ -42,8 +39,6 @@ namespace Lineside {
     std::unique_ptr<Tendril::BinaryOutputPin> green;
     
     std::vector<std::unique_ptr<Tendril::BinaryOutputPin>> feathers;
-  private:
-    friend class DirectDriveMASHData;
     
     void turnAllOff();
 

--- a/liblineside/test/boparraymashtests.cpp
+++ b/liblineside/test/boparraymashtests.cpp
@@ -1,79 +1,97 @@
 #include <boost/test/unit_test.hpp>
 
 #include "tendril/mocks/mockboparray.hpp"
+#include "tendril/mocks/mockboparrayprovider.hpp"
 
 #include "lineside/boparraymash.hpp"
+#include "lineside/boparraymashdata.hpp"
+
+#include "mockmanagerfixture.hpp"
 
 // =======================================
 
-BOOST_AUTO_TEST_SUITE(BOPArrayMASH)
+BOOST_FIXTURE_TEST_SUITE(BOPArrayMASH, MockManagerFixture)
 
 BOOST_AUTO_TEST_CASE(TwoAspect)
 {
   const Lineside::ItemId id(16);
-
-  // Create the target
-  Lineside::BOPArrayMASH target(id);
-  target.pins = std::make_unique<Tendril::Mocks::MockBOPArray>(2);
+  
   const size_t redPin = 0;
   const size_t greenPin = 1;
-  target.aspects[Lineside::SignalAspect::Red] = redPin;
-  target.aspects[Lineside::SignalAspect::Green] = greenPin;
-  // Remember that the first feather is ignored, but it needs to be present
-  target.feathers.push_back(8192);
+
+  Lineside::BOPArrayMASHData mashd;
+  mashd.id = id;
+  mashd.settings["Red"] = std::to_string(redPin);
+  mashd.settings["Green"] = std::to_string(greenPin);
+  mashd.bopArrayRequest.controller = "MockBOPArray";
+  mashd.bopArrayRequest.controllerData = "ArrayForTest";
+  mashd.bopArrayRequest.settings[std::to_string(redPin)] = "100";
+  mashd.bopArrayRequest.settings[std::to_string(greenPin)] = "128";
+  BOOST_TEST_PASSPOINT();
+
+  // Create the target
+  auto pwItem = mashd.Construct( *(this->hwManager), *(this->swManager) );
+  BOOST_REQUIRE( pwItem );
+  auto target = std::dynamic_pointer_cast<Lineside::BOPArrayMASH>(pwItem);
+  BOOST_REQUIRE( target );
+  BOOST_TEST_PASSPOINT();
 
   // Get access to the MockBOPArray
-  auto mba = dynamic_cast<Tendril::Mocks::MockBOPArray*>(target.pins.get());
+  auto hp = this->hwManager->bopArrayProviderRegistrar.Retrieve("MockBOPArray");
+  BOOST_REQUIRE( hp );
+  auto mbp = std::dynamic_pointer_cast<Tendril::Mocks::MockBOPArrayProvider>(hp);
+  BOOST_REQUIRE( mbp );
+  auto mba = dynamic_cast<Tendril::Mocks::MockBOPArray*>(mbp->hardware.at("ArrayForTest"));
   BOOST_REQUIRE( mba );
 
   // Construction state
-  BOOST_CHECK_EQUAL( target.getId(), id );
+  BOOST_CHECK_EQUAL( target->getId(), id );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
   
   // Activate
-  target.OnActivate();
+  target->OnActivate();
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), true );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
   
   // Set to green
-  target.SetState(Lineside::SignalState::Green,
-		  Lineside::SignalFlash::Steady,
-		  0);
-  auto sleepTime = target.OnRun();
+  target->SetState(Lineside::SignalState::Green,
+		   Lineside::SignalFlash::Steady,
+		   0);
+  auto sleepTime = target->OnRun();
   BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), true );
 
   // Call OnRun again, but we didn't set it flashing
-  sleepTime = target.OnRun();
+  sleepTime = target->OnRun();
   BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), true );
 
   // Set to flashing red
-  target.SetState(Lineside::SignalState::Red,
-		  Lineside::SignalFlash::Flashing,
-		  0);
-  sleepTime = target.OnRun();
+  target->SetState(Lineside::SignalState::Red,
+		   Lineside::SignalFlash::Flashing,
+		   0);
+  sleepTime = target->OnRun();
   BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), true );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
 
   // Call OnRun again, and this time we are flashing
-  sleepTime = target.OnRun();
+  sleepTime = target->OnRun();
   BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
 
   // And one more time, since the aspect should be back on
-  sleepTime = target.OnRun();
+  sleepTime = target->OnRun();
   BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), true );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
 
   // Deactivate
-  target.OnDeactivate();
+  target->OnDeactivate();
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
 }
@@ -81,71 +99,86 @@ BOOST_AUTO_TEST_CASE(TwoAspect)
 BOOST_AUTO_TEST_CASE(TwoAspectOneFeather)
 {
   const Lineside::ItemId id(15);
-  
-  // Create the target
-  Lineside::BOPArrayMASH target(id);
-  target.pins = std::make_unique<Tendril::Mocks::MockBOPArray>(3);
+    
   const size_t redPin = 0;
   const size_t greenPin = 2;
   const size_t featherPin = 1;
-  target.aspects[Lineside::SignalAspect::Red] = redPin;
-  target.aspects[Lineside::SignalAspect::Green] = greenPin;
-  // Remember that the first feather is ignored, but it needs to be present
-  target.feathers.push_back(8192);
-  target.feathers.push_back(featherPin);
+
+  Lineside::BOPArrayMASHData mashd;
+  mashd.id = id;
+  mashd.settings["Red"] = std::to_string(redPin);
+  mashd.settings["Green"] = std::to_string(greenPin);
+  mashd.settings["Feather1"] = std::to_string(featherPin);
+  mashd.bopArrayRequest.controller = "MockBOPArray";
+  mashd.bopArrayRequest.controllerData = "ArrayForTest";
+  mashd.bopArrayRequest.settings[std::to_string(redPin)] = "100";
+  mashd.bopArrayRequest.settings[std::to_string(greenPin)] = "128";
+  mashd.bopArrayRequest.settings[std::to_string(featherPin)] = "129";
+  BOOST_TEST_PASSPOINT();
+
+  // Create the target
+  auto pwItem = mashd.Construct( *(this->hwManager), *(this->swManager) );
+  BOOST_REQUIRE( pwItem );
+  auto target = std::dynamic_pointer_cast<Lineside::BOPArrayMASH>(pwItem);
+  BOOST_REQUIRE( target );
+  BOOST_TEST_PASSPOINT();
 
   // Get access to the MockBOPArray
-  auto mba = dynamic_cast<Tendril::Mocks::MockBOPArray*>(target.pins.get());
+  auto hp = this->hwManager->bopArrayProviderRegistrar.Retrieve("MockBOPArray");
+  BOOST_REQUIRE( hp );
+  auto mbp = std::dynamic_pointer_cast<Tendril::Mocks::MockBOPArrayProvider>(hp);
+  BOOST_REQUIRE( mbp );
+  auto mba = dynamic_cast<Tendril::Mocks::MockBOPArray*>(mbp->hardware.at("ArrayForTest"));
   BOOST_REQUIRE( mba );
 
   // Construction state
-  BOOST_CHECK_EQUAL( target.getId(), id );
+  BOOST_CHECK_EQUAL( target->getId(), id );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin), false );
   
   // Activate
-  target.OnActivate();
+  target->OnActivate();
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), true );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin), false );
   
   // Set to flashing green with the feather on
-  target.SetState(Lineside::SignalState::Green,
-		  Lineside::SignalFlash::Flashing,
-		  1);
-  auto sleepTime = target.OnRun();
+  target->SetState(Lineside::SignalState::Green,
+		   Lineside::SignalFlash::Flashing,
+		   1);
+  auto sleepTime = target->OnRun();
   BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), true );
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin), true );
 
   // Call OnRun, green aspect should go out, but feather stays on
-  sleepTime = target.OnRun();
+  sleepTime = target->OnRun();
   BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin), true );
 
   // Call once more, and the green aspect comes back on
-  sleepTime = target.OnRun();
+  sleepTime = target->OnRun();
   BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), true );
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin), true );
-
+  
   // Now go for steady green without a feather
-  target.SetState(Lineside::SignalState::Green,
-		  Lineside::SignalFlash::Steady,
-		  0);
-  sleepTime = target.OnRun();
+  target->SetState(Lineside::SignalState::Green,
+		   Lineside::SignalFlash::Steady,
+		   0);
+  sleepTime = target->OnRun();
   BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), true );
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin), false );
   
   // Deactivate
-  target.OnDeactivate();
+  target->OnDeactivate();
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin), false );
@@ -154,44 +187,59 @@ BOOST_AUTO_TEST_CASE(TwoAspectOneFeather)
 BOOST_AUTO_TEST_CASE(TwoAspectTwoFeather)
 {
   const Lineside::ItemId id(3253);
-
-  // Create the target
-  Lineside::BOPArrayMASH target(id);
-  target.pins = std::make_unique<Tendril::Mocks::MockBOPArray>(4);
   const size_t redPin = 1;
   const size_t greenPin = 2;
   const size_t featherPin1 = 3;
   const size_t featherPin2 = 0;
-  target.aspects[Lineside::SignalAspect::Red] = redPin;
-  target.aspects[Lineside::SignalAspect::Green] = greenPin;
-  // Remember that the first feather is ignored, but it needs to be present
-  target.feathers.push_back(8192);
-  target.feathers.push_back(featherPin1);
-  target.feathers.push_back(featherPin2);
+  
+  Lineside::BOPArrayMASHData mashd;
+  mashd.id = id;
+  mashd.settings["Red"] = std::to_string(redPin);
+  mashd.settings["Green"] = std::to_string(greenPin);
+  mashd.settings["Feather1"] = std::to_string(featherPin1);
+  mashd.settings["Feather2"] = std::to_string(featherPin2);
+  mashd.bopArrayRequest.controller = "MockBOPArray";
+  mashd.bopArrayRequest.controllerData = "ArrayForTest";
+  mashd.bopArrayRequest.settings[std::to_string(redPin)] = "100";
+  mashd.bopArrayRequest.settings[std::to_string(greenPin)] = "128";
+  mashd.bopArrayRequest.settings[std::to_string(featherPin1)] = "129";
+  mashd.bopArrayRequest.settings[std::to_string(featherPin2)] = "144";
+  BOOST_TEST_PASSPOINT();
+
+  // Create the target
+  auto pwItem = mashd.Construct( *(this->hwManager), *(this->swManager) );
+  BOOST_REQUIRE( pwItem );
+  auto target = std::dynamic_pointer_cast<Lineside::BOPArrayMASH>(pwItem);
+  BOOST_REQUIRE( target );
+  BOOST_TEST_PASSPOINT();
 
   // Get access to the MockBOPArray
-  auto mba = dynamic_cast<Tendril::Mocks::MockBOPArray*>(target.pins.get());
+  auto hp = this->hwManager->bopArrayProviderRegistrar.Retrieve("MockBOPArray");
+  BOOST_REQUIRE( hp );
+  auto mbp = std::dynamic_pointer_cast<Tendril::Mocks::MockBOPArrayProvider>(hp);
+  BOOST_REQUIRE( mbp );
+  auto mba = dynamic_cast<Tendril::Mocks::MockBOPArray*>(mbp->hardware.at("ArrayForTest"));
   BOOST_REQUIRE( mba );
 
   // Construction state
-  BOOST_CHECK_EQUAL( target.getId(), id );
+  BOOST_CHECK_EQUAL( target->getId(), id );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin1), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin2), false );
 
   // Activate
-  target.OnActivate();
+  target->OnActivate();
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), true );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin1), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin2), false );
 
   // Set to green with one feather
-  target.SetState(Lineside::SignalState::Green,
-		  Lineside::SignalFlash::Steady,
-		  1);
-  auto sleepTime = target.OnRun();
+  target->SetState(Lineside::SignalState::Green,
+		   Lineside::SignalFlash::Steady,
+		   1);
+  auto sleepTime = target->OnRun();
   BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), true );
@@ -199,10 +247,10 @@ BOOST_AUTO_TEST_CASE(TwoAspectTwoFeather)
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin2), false );
 
   // And green with the other feather
-  target.SetState(Lineside::SignalState::Green,
-		  Lineside::SignalFlash::Steady,
-		  2);
-  sleepTime = target.OnRun();
+  target->SetState(Lineside::SignalState::Green,
+		   Lineside::SignalFlash::Steady,
+		   2);
+  sleepTime = target->OnRun();
   BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), true );
@@ -210,10 +258,10 @@ BOOST_AUTO_TEST_CASE(TwoAspectTwoFeather)
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin2), true );
   
   // Green without feathers
-  target.SetState(Lineside::SignalState::Green,
-		  Lineside::SignalFlash::Steady,
-		  0);
-  sleepTime = target.OnRun();
+  target->SetState(Lineside::SignalState::Green,
+		   Lineside::SignalFlash::Steady,
+		   0);
+  sleepTime = target->OnRun();
   BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), true );
@@ -221,7 +269,7 @@ BOOST_AUTO_TEST_CASE(TwoAspectTwoFeather)
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin2), false );
 
   // Deactivate
-  target.OnDeactivate();
+  target->OnDeactivate();
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(featherPin1), false );
@@ -231,45 +279,59 @@ BOOST_AUTO_TEST_CASE(TwoAspectTwoFeather)
 BOOST_AUTO_TEST_CASE(ThreeAspect)
 {
   const Lineside::ItemId id(116731);
-
-  // Create the target
-  Lineside::BOPArrayMASH target(id);
-  target.pins = std::make_unique<Tendril::Mocks::MockBOPArray>(3);
   const size_t redPin = 1;
   const size_t yellowPin = 0;
   const size_t greenPin = 2;
-  target.aspects[Lineside::SignalAspect::Red] = redPin;
-  target.aspects[Lineside::SignalAspect::Yellow1] = yellowPin;
-  target.aspects[Lineside::SignalAspect::Green] = greenPin;
-  // Remember that the first feather is ignored, but it needs to be present
-  target.feathers.push_back(8192);
+
+  Lineside::BOPArrayMASHData mashd;
+  mashd.id = id;
+  mashd.settings["Red"] = std::to_string(redPin);
+  mashd.settings["Green"] = std::to_string(greenPin);
+  mashd.settings["Yellow1"] = std::to_string(yellowPin);
+  mashd.bopArrayRequest.controller = "MockBOPArray";
+  mashd.bopArrayRequest.controllerData = "ArrayForTest";
+  mashd.bopArrayRequest.settings[std::to_string(redPin)] = "100";
+  mashd.bopArrayRequest.settings[std::to_string(greenPin)] = "128";
+  mashd.bopArrayRequest.settings[std::to_string(yellowPin)] = "129";
+  BOOST_TEST_PASSPOINT();
+
+  // Create the target
+  auto pwItem = mashd.Construct( *(this->hwManager), *(this->swManager) );
+  BOOST_REQUIRE( pwItem );
+  auto target = std::dynamic_pointer_cast<Lineside::BOPArrayMASH>(pwItem);
+  BOOST_REQUIRE( target );
+  BOOST_TEST_PASSPOINT();
 
   // Get access to the MockBOPArray
-  auto mba = dynamic_cast<Tendril::Mocks::MockBOPArray*>(target.pins.get());
+  auto hp = this->hwManager->bopArrayProviderRegistrar.Retrieve("MockBOPArray");
+  BOOST_REQUIRE( hp );
+  auto mbp = std::dynamic_pointer_cast<Tendril::Mocks::MockBOPArrayProvider>(hp);
+  BOOST_REQUIRE( mbp );
+  auto mba = dynamic_cast<Tendril::Mocks::MockBOPArray*>(mbp->hardware.at("ArrayForTest"));
   BOOST_REQUIRE( mba );
   
   // Construction state
-  BOOST_CHECK_EQUAL( target.getId(), id );
+  BOOST_CHECK_EQUAL( target->getId(), id );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(yellowPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
   
   // Activate
-  target.OnActivate();
+  target->OnActivate();
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), true );
   BOOST_CHECK_EQUAL( mba->outputs.at(yellowPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
   
   // Set to yellow and steady
-  target.SetState(Lineside::SignalState::Yellow, Lineside::SignalFlash::Steady, 0);
-  auto sleepTime = target.OnRun();
+  target->SetState(Lineside::SignalState::Yellow, Lineside::SignalFlash::Steady, 0);
+  auto sleepTime = target->OnRun();
   BOOST_CHECK( sleepTime == std::chrono::milliseconds(500) );
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(yellowPin), true );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );
   
   // Deactivate
-  target.OnDeactivate();
+  target->OnDeactivate();
   BOOST_CHECK_EQUAL( mba->outputs.at(redPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(yellowPin), false );
   BOOST_CHECK_EQUAL( mba->outputs.at(greenPin), false );

--- a/liblineside/test/directdrivemashtests.cpp
+++ b/liblineside/test/directdrivemashtests.cpp
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(TwoAspect)
   auto hp = this->hwManager->bopProviderRegistrar.Retrieve("MockBOP");
   BOOST_REQUIRE( hp );
   auto mbp = std::dynamic_pointer_cast<MockBOPProvider>(hp);
-  BOOST_REQUIRE( hp );
+  BOOST_REQUIRE( mbp );
   auto red = mbp->hardware.at("10");
   auto green = mbp->hardware.at("11");
   BOOST_REQUIRE( red );
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(TwoAspectOneFeather)
   auto hp = this->hwManager->bopProviderRegistrar.Retrieve("MockBOP");
   BOOST_REQUIRE( hp );
   auto mbp = std::dynamic_pointer_cast<MockBOPProvider>(hp);
-  BOOST_REQUIRE( hp );
+  BOOST_REQUIRE( mbp );
   auto red = mbp->hardware.at("10");
   auto green = mbp->hardware.at("11");
   auto feather = mbp->hardware.at("19");
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(TwoAspectTwoFeather)
   auto hp = this->hwManager->bopProviderRegistrar.Retrieve("MockBOP");
   BOOST_REQUIRE( hp );
   auto mbp = std::dynamic_pointer_cast<MockBOPProvider>(hp);
-  BOOST_REQUIRE( hp );
+  BOOST_REQUIRE( mbp );
   auto red = mbp->hardware.at("10");
   auto green = mbp->hardware.at("11");
   auto feather1 = mbp->hardware.at("19");
@@ -347,7 +347,7 @@ BOOST_AUTO_TEST_CASE( ThreeAspect )
   auto hp = this->hwManager->bopProviderRegistrar.Retrieve("MockBOP");
   BOOST_REQUIRE( hp );
   auto mbp = std::dynamic_pointer_cast<MockBOPProvider>(hp);
-  BOOST_REQUIRE( hp );
+  BOOST_REQUIRE( mbp );
   auto red = mbp->hardware.at("15");
   auto green = mbp->hardware.at("16");
   auto yellow1 = mbp->hardware.at("10");
@@ -444,7 +444,7 @@ BOOST_AUTO_TEST_CASE( FourAspect )
   auto hp = this->hwManager->bopProviderRegistrar.Retrieve("MockBOP");
   BOOST_REQUIRE( hp );
   auto mbp = std::dynamic_pointer_cast<MockBOPProvider>(hp);
-  BOOST_REQUIRE( hp );
+  BOOST_REQUIRE( mbp );
   auto red = mbp->hardware.at("15");
   auto green = mbp->hardware.at("16");
   auto yellow1 = mbp->hardware.at("11");


### PR DESCRIPTION
For ease of testing, the various hardware fields in `DirectDriveMASH` and `BOPArrayMASH` had been made public. Now that things are separated, make them private (again).