### PR TITLE
Basic implementation of SN74x595 Shift Register

### DIFF
--- a/libpigpiodpp/CMakeLists.txt
+++ b/libpigpiodpp/CMakeLists.txt
@@ -23,3 +23,4 @@ configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/include/pigpiodpp/piavailable.hpp.i
   "${CMAKE_CURRENT_SOURCE_DIR}/include/pigpiodpp/piavailable.hpp" )
 add_subdirectory(src)
 add_subdirectory(test)
+add_subdirectory(apps)

--- a/libpigpiodpp/apps/CMakeLists.txt
+++ b/libpigpiodpp/apps/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(dd595)

--- a/libpigpiodpp/apps/dd595/CMakeLists.txt
+++ b/libpigpiodpp/apps/dd595/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(srcs)
+
+list(APPEND srcs main.cpp)
+list(APPEND srcs cmdlineopts.cpp)
+
+add_executable(dd595 ${srcs})
+target_link_libraries(dd595 PUBLIC pigpiodpp Boost::program_options)

--- a/libpigpiodpp/apps/dd595/CMakeLists.txt
+++ b/libpigpiodpp/apps/dd595/CMakeLists.txt
@@ -2,6 +2,7 @@ set(srcs)
 
 list(APPEND srcs main.cpp)
 list(APPEND srcs cmdlineopts.cpp)
+list(APPEND srcs runonconsole.cpp)
 
 add_executable(dd595 ${srcs})
 target_link_libraries(dd595 PUBLIC pigpiodpp Boost::program_options)

--- a/libpigpiodpp/apps/dd595/cmdlineopts.cpp
+++ b/libpigpiodpp/apps/dd595/cmdlineopts.cpp
@@ -1,0 +1,64 @@
+#include <iostream>
+#include <boost/program_options.hpp>
+
+#include "cmdlineopts.hpp"
+
+namespace bpo = boost::program_options;
+
+
+void CmdLineOpts::Populate(int argc, char* argv[]) {
+  const std::string clockOpt = "clock";
+  const std::string clockOptDesc = "GPIO pin for clock";
+
+  const std::string dataOpt = "data";
+  const std::string dataOptDesc = "GPIO pin for data";
+
+  const std::string latchOpt = "latch";
+  const std::string latchOptDesc = "GPIO pin for latch";
+
+  const std::string chainOpt = "chain";
+  const std::string chainOptDesc = "Number of shift registers in chain";
+
+  bpo::options_description desc("Allowed Options");
+  desc.add_options()
+    ("help", "Show help message")
+    (clockOpt.c_str(), bpo::value<std::string>(&(this->clockPin)), clockOptDesc.c_str())
+    (dataOpt.c_str(), bpo::value<std::string>(&(this->dataPin)), dataOptDesc.c_str())
+    (latchOpt.c_str(), bpo::value<std::string>(&(this->latchPin)), latchOptDesc.c_str())
+    (chainOpt.c_str(), bpo::value<int>(&(this->chainLength)), chainOptDesc.c_str())
+    ;
+  
+  bpo::variables_map vm;
+  bpo::store(bpo::parse_command_line(argc, argv, desc), vm);
+  bpo::notify(vm);
+
+  if( vm.count("help") ) {
+    std::cout << desc << std::endl;
+    this->helpMessagePrinted = true;
+    return;
+  }
+  
+  if( vm.count(clockOpt.c_str()) ) {
+    std::cout << "Clock pin: " << this->clockPin << std::endl;
+  } else {
+    throw std::runtime_error("Clock pin not specified");
+  }
+  
+  if( vm.count(dataOpt.c_str()) ) {
+    std::cout << "Data pin : " << this->dataPin << std::endl;
+  } else {
+    throw std::runtime_error("Data pin not specified");
+  }
+
+  if( vm.count(latchOpt.c_str()) ) {
+    std::cout << "Latch pin: " << this->latchPin << std::endl;
+  } else {
+    throw std::runtime_error("Latch pin not specified");
+  }
+
+  if( vm.count(chainOpt.c_str()) ) {
+    std::cout << "Devices in chain : " << this->chainLength << std::endl;
+  } else {
+    throw std::runtime_error("Device in chain not specified");
+  }
+}

--- a/libpigpiodpp/apps/dd595/cmdlineopts.hpp
+++ b/libpigpiodpp/apps/dd595/cmdlineopts.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+class CmdLineOpts {
+public:
+  CmdLineOpts() :
+    helpMessagePrinted(false),
+    clockPin(),
+    dataPin(),
+    latchPin(),
+    chainLength(-1) {}
+
+  bool helpMessagePrinted;
+  std::string clockPin;
+  std::string dataPin;
+  std::string latchPin;
+  int chainLength;
+
+  void Populate(int argc, char* argv[]);
+};

--- a/libpigpiodpp/apps/dd595/main.cpp
+++ b/libpigpiodpp/apps/dd595/main.cpp
@@ -28,11 +28,25 @@ int main(int argc, char* argv[]) {
     auto ltch = provider->GetHardware(opts.latchPin, emptySettings);
     std::unique_ptr<Tendril::BinaryOutputPin> noConnect;
 
-    Tendril::Devices::DirectDriveSN74x595 shifter("SN74x595",
-						  opts.chainLength,
-						  clk, data, ltch, noConnect, noConnect);
+    auto shifter = std::make_shared<Tendril::Devices::DirectDriveSN74x595>("SN74x595",
+									   opts.chainLength,
+									   clk,
+									   data,
+									   ltch,
+									   noConnect,
+									   noConnect);
+    
+    std::cout << "Created shifter, now creating BOPArray" << std::endl;
+    
+    Tendril::SettingsMap bopaSettings;
+    for( unsigned int i=0; i<shifter->totalPins; ++i ) {
+      std::string mapping = std::to_string(i);
+      bopaSettings[mapping] = mapping;
+    }
 
-    RunOnConsole(shifter);
+    auto bopArray = shifter->GetHardware( "ShiftArray", bopaSettings );
+
+    RunOnConsole(*bopArray, shifter->totalPins);
   }
   catch( std::exception& e ) {
     std::cerr << "Error: " << e.what() << std::endl;

--- a/libpigpiodpp/apps/dd595/main.cpp
+++ b/libpigpiodpp/apps/dd595/main.cpp
@@ -7,6 +7,7 @@
 #include "tendril/devices/directdrivesn74x595.hpp"
 
 #include "cmdlineopts.hpp"
+#include "runonconsole.hpp"
 
 int main(int argc, char* argv[]) {
   std::cout << "Tester for directly driven SN74x595" << std::endl;
@@ -30,6 +31,8 @@ int main(int argc, char* argv[]) {
     Tendril::Devices::DirectDriveSN74x595 shifter("SN74x595",
 						  opts.chainLength,
 						  clk, data, ltch, noConnect, noConnect);
+
+    RunOnConsole(shifter);
   }
   catch( std::exception& e ) {
     std::cerr << "Error: " << e.what() << std::endl;

--- a/libpigpiodpp/apps/dd595/main.cpp
+++ b/libpigpiodpp/apps/dd595/main.cpp
@@ -1,0 +1,40 @@
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+#include "pigpiodpp/pimanager.hpp"
+#include "pigpiodpp/pibopprovider.hpp"
+#include "tendril/devices/directdrivesn74x595.hpp"
+
+#include "cmdlineopts.hpp"
+
+int main(int argc, char* argv[]) {
+  std::cout << "Tester for directly driven SN74x595" << std::endl;
+
+  try {
+    CmdLineOpts opts;
+    opts.Populate(argc, argv);
+    if( opts.helpMessagePrinted ) {
+      return EXIT_SUCCESS;
+    }
+
+    auto pi = PiGPIOdpp::PiManager::CreatePiManager();
+    auto provider = std::make_shared<PiGPIOdpp::PiBOPProvider>(pi);
+
+    Tendril::SettingsMap emptySettings;
+    auto clk = provider->GetHardware(opts.clockPin, emptySettings);
+    auto data = provider->GetHardware(opts.dataPin, emptySettings);
+    auto ltch = provider->GetHardware(opts.latchPin, emptySettings);
+    std::unique_ptr<Tendril::BinaryOutputPin> noConnect;
+
+    Tendril::Devices::DirectDriveSN74x595 shifter("SN74x595",
+						  opts.chainLength,
+						  clk, data, ltch, noConnect, noConnect);
+  }
+  catch( std::exception& e ) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  
+  return EXIT_SUCCESS;
+}

--- a/libpigpiodpp/apps/dd595/runonconsole.cpp
+++ b/libpigpiodpp/apps/dd595/runonconsole.cpp
@@ -10,9 +10,9 @@ std::vector<unsigned int> ToBoolArray(const size_t value, const unsigned int num
   result.resize(numBits);
 
   unsigned int iShift = 0;
-  for( auto it=result.begin(); it!=result.end(); ++it ) {
+  for( auto it=result.rbegin(); it!=result.rend(); ++it ) {
     bool nxt = value & ( 1 << iShift );
-    result.at(iShift) = nxt;
+    *it = nxt;
     
     iShift++;
   }
@@ -25,7 +25,7 @@ std::vector<unsigned int> ToBoolArray(const size_t value, const unsigned int num
   return result;
 }
 
-void RunOnConsole(Tendril::Devices::DirectDriveSN74x595& shifter) {
+void RunOnConsole(Tendril::BOPArray& bopa, const size_t nPins) {
   std::cout << "Entering main loop" << std::endl;
 
   bool done = false;
@@ -41,13 +41,13 @@ void RunOnConsole(Tendril::Devices::DirectDriveSN74x595& shifter) {
       try {
 	size_t pattern = std::stoull(inputLine);
 
-	auto values = ToBoolArray( pattern, shifter.totalPins );
+	auto values = ToBoolArray( pattern, nPins );
 	std::map<unsigned int,bool> updateRequest;
 	for( unsigned int i=0; i<values.size(); ++i ) {
-	  updateRequest[i] = values.at(i);
+	  bopa.Set(i, values.at(i));
 	}
 
-	shifter.SetPinsAndSend( updateRequest );
+	bopa.Update();
       }
       catch( std::exception& e ) {
         std::cerr << e.what() << std::endl;

--- a/libpigpiodpp/apps/dd595/runonconsole.cpp
+++ b/libpigpiodpp/apps/dd595/runonconsole.cpp
@@ -1,0 +1,58 @@
+#include <string>
+#include <vector>
+#include <iostream>
+#include <map>
+
+#include "runonconsole.hpp"
+
+std::vector<unsigned int> ToBoolArray(const size_t value, const unsigned int numBits) {
+  std::vector<unsigned int> result;
+  result.resize(numBits);
+
+  unsigned int iShift = 0;
+  for( auto it=result.begin(); it!=result.end(); ++it ) {
+    bool nxt = value & ( 1 << iShift );
+    result.at(iShift) = nxt;
+    
+    iShift++;
+  }
+
+  for( auto it=result.begin(); it!=result.end(); ++it ) {
+    std::cout << *it;
+  }
+  std::cout << std::endl;
+  
+  return result;
+}
+
+void RunOnConsole(Tendril::Devices::DirectDriveSN74x595& shifter) {
+  std::cout << "Entering main loop" << std::endl;
+
+  bool done = false;
+  
+  while( !done ) {
+    std::string inputLine;
+      
+    std::getline( std::cin, inputLine );
+    if( inputLine == "q" ) {
+      std::cout << "Received quit" << std::endl;
+      done = true;
+    } else {
+      try {
+	size_t pattern = std::stoull(inputLine);
+
+	auto values = ToBoolArray( pattern, shifter.totalPins );
+	std::map<unsigned int,bool> updateRequest;
+	for( unsigned int i=0; i<values.size(); ++i ) {
+	  updateRequest[i] = values.at(i);
+	}
+
+	shifter.SetPinsAndSend( updateRequest );
+      }
+      catch( std::exception& e ) {
+        std::cerr << e.what() << std::endl;
+        continue;
+      }      
+    }
+  }
+}

--- a/libpigpiodpp/apps/dd595/runonconsole.hpp
+++ b/libpigpiodpp/apps/dd595/runonconsole.hpp
@@ -1,5 +1,5 @@
 #pragma once
 
-#include "tendril/devices/directdrivesn74x595.hpp"
+#include "tendril/boparray.hpp"
 
-void RunOnConsole(Tendril::Devices::DirectDriveSN74x595& shifter);
+void RunOnConsole(Tendril::BOPArray& bopa, const size_t nPins);

--- a/libpigpiodpp/apps/dd595/runonconsole.hpp
+++ b/libpigpiodpp/apps/dd595/runonconsole.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "tendril/devices/directdrivesn74x595.hpp"
+
+void RunOnConsole(Tendril::Devices::DirectDriveSN74x595& shifter);

--- a/libtendril/include/tendril/devices/boparray595.hpp
+++ b/libtendril/include/tendril/devices/boparray595.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "tendril/boparray.hpp"
+
+namespace Tendril::Devices {
+  class DirectDriveSN74x595;
+
+  //! A BOPArray controlled by an SN74x595 shift register
+  class BOPArray595 : BOPArray {
+  public:
+    //! Create an instance
+    BOPArray595(std::shared_ptr<DirectDriveSN74x595> controller,
+		std::vector<unsigned int> pins);
+
+    virtual void Update() override;
+  private:
+    std::shared_ptr<DirectDriveSN74x595> controller;
+    std::vector<unsigned int> pinMapping;
+  };
+}

--- a/libtendril/include/tendril/devices/boparray595.hpp
+++ b/libtendril/include/tendril/devices/boparray595.hpp
@@ -9,7 +9,7 @@ namespace Tendril::Devices {
   class DirectDriveSN74x595;
 
   //! A BOPArray controlled by an SN74x595 shift register
-  class BOPArray595 : BOPArray {
+  class BOPArray595 : public BOPArray {
   public:
     //! Create an instance
     BOPArray595(std::shared_ptr<DirectDriveSN74x595> controller,

--- a/libtendril/include/tendril/devices/directdrivesn74x595.hpp
+++ b/libtendril/include/tendril/devices/directdrivesn74x595.hpp
@@ -57,6 +57,9 @@ namespace Tendril::Devices {
       imprecise.
      */
     std::chrono::microseconds levelDelay;
+
+    //! Total number of pins available for use
+    const unsigned int totalPins;
   private:
     std::mutex updateMutex;
 
@@ -65,8 +68,7 @@ namespace Tendril::Devices {
     std::unique_ptr<BinaryOutputPin> latchPin;
     std::unique_ptr<BinaryOutputPin> enablePin;
     std::unique_ptr<BinaryOutputPin> clearPin;
-
-    const unsigned int totalPins;
+    
     std::vector<bool> state;
     std::set<unsigned int> allocatedPins;
   };

--- a/libtendril/include/tendril/devices/directdrivesn74x595.hpp
+++ b/libtendril/include/tendril/devices/directdrivesn74x595.hpp
@@ -7,6 +7,8 @@
 #include "tendril/boparray.hpp"
 #include "tendril/hardwareprovider.hpp"
 
+#include "tendril/devices/device.hpp"
+
 namespace Tendril::Devices {
   class DD595BOPArray;
   

--- a/libtendril/include/tendril/devices/directdrivesn74x595.hpp
+++ b/libtendril/include/tendril/devices/directdrivesn74x595.hpp
@@ -2,6 +2,8 @@
 
 #include <mutex>
 #include <chrono>
+#include <set>
+#include <vector>
 
 #include "tendril/binaryoutputpin.hpp"
 #include "tendril/boparray.hpp"
@@ -10,13 +12,21 @@
 #include "tendril/devices/device.hpp"
 
 namespace Tendril::Devices {
-  class DD595BOPArray;
-  
   //! Class to represent directly driven chained SN74x595 shift registers
+  /*!
+    The goal of this class is to allow the shift registers to be used
+    to provide more output pins. It does not make the 'shift-by-one' operation
+    publically available.
+  */
   class DirectDriveSN74x595 : public Device,
 			      public HardwareProvider<BOPArray> {
   public:
-    const std::chrono::nanoseconds DefaultLevelDelay = std::chrono::nanoseconds(10);
+    const std::chrono::microseconds DefaultLevelDelay = std::chrono::microseconds(10);
+
+    /*
+      Constructor needs to set number of registers in chain.
+      Also make sure that the reset pin (if specified) is set to high
+    */
     
     //! Register with the HardwareManager
     virtual void Register(HardwareManager& hwManager) override;
@@ -42,9 +52,8 @@ namespace Tendril::Devices {
       Since this is passed to sleep() the exact wait is
       imprecise.
      */
-    std::chrono::nanoseconds levelDelay;
+    std::chrono::microseconds levelDelay;
   private:
-    friend class DD595BOPArray;
 
     std::mutex updateMutex;
 
@@ -55,6 +64,6 @@ namespace Tendril::Devices {
     std::unique_ptr<BinaryOutputPin> clearPin;
 
     std::vector<bool> state;
-    std::vector<unsigned int> allocatedPins;
+    std::set<unsigned int> allocatedPins;
   };
 }

--- a/libtendril/include/tendril/devices/directdrivesn74x595.hpp
+++ b/libtendril/include/tendril/devices/directdrivesn74x595.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <mutex>
+#include <chrono>
+
+#include "tendril/binaryoutputpin.hpp"
+#include "tendril/boparray.hpp"
+#include "tendril/hardwareprovider.hpp"
+
+namespace Tendril::Devices {
+  class DD595BOPArray;
+  
+  //! Class to represent directly driven chained SN74x595 shift registers
+  class DirectDriveSN74x595 : public Device,
+			      public HardwareProvider<BOPArray> {
+  public:
+    const std::chrono::nanoseconds DefaultLevelDelay = std::chrono::nanoseconds(10);
+    
+    //! Register with the HardwareManager
+    virtual void Register(HardwareManager& hwManager) override;
+
+    //! Fetch a BOPArray
+    virtual std::unique_ptr<BOPArray>
+    GetHardware(const std::string& hardwareId,
+		const SettingsMap& settings) override;
+
+    void EnableOutputs(bool enable);
+
+    void Reset();
+
+    void SetPinsAndSend(const std::map<unsigned int,bool>& pinUpdates);
+    
+    //! Delay to allow output pin level to stabilise
+    /*!
+      This is the delay between pin updates. For example,
+      this is the delay imposed between the dataPin level being set
+      and the clockPin being set to high. The clockPin will
+      also then remain high for at least this long.
+      
+      Since this is passed to sleep() the exact wait is
+      imprecise.
+     */
+    std::chrono::nanoseconds levelDelay;
+  private:
+    friend class DD595BOPArray;
+
+    std::mutex updateMutex;
+
+    std::unique_ptr<BinaryOutputPin> clockPin;
+    std::unique_ptr<BinaryOutputPin> dataPin;
+    std::unique_ptr<BinaryOutputPin> latchPin;
+    std::unique_ptr<BinaryOutputPin> enablePin;
+    std::unique_ptr<BinaryOutputPin> clearPin;
+
+    std::vector<bool> state;
+    std::vector<unsigned int> allocatedPins;
+  };
+}

--- a/libtendril/include/tendril/devices/directdrivesn74x595.hpp
+++ b/libtendril/include/tendril/devices/directdrivesn74x595.hpp
@@ -22,11 +22,15 @@ namespace Tendril::Devices {
 			      public HardwareProvider<BOPArray> {
   public:
     const std::chrono::microseconds DefaultLevelDelay = std::chrono::microseconds(10);
-
-    /*
-      Constructor needs to set number of registers in chain.
-      Also make sure that the reset pin (if specified) is set to high
-    */
+    const unsigned int PinsPerChip = 8;
+    
+    DirectDriveSN74x595(const std::string deviceName,
+			const unsigned int chainLength,
+			std::unique_ptr<BinaryOutputPin>& clock,
+			std::unique_ptr<BinaryOutputPin>& data,
+			std::unique_ptr<BinaryOutputPin>& latch,
+			std::unique_ptr<BinaryOutputPin>& enable,
+			std::unique_ptr<BinaryOutputPin>& clear );
     
     //! Register with the HardwareManager
     virtual void Register(HardwareManager& hwManager) override;
@@ -54,7 +58,6 @@ namespace Tendril::Devices {
      */
     std::chrono::microseconds levelDelay;
   private:
-
     std::mutex updateMutex;
 
     std::unique_ptr<BinaryOutputPin> clockPin;
@@ -63,6 +66,7 @@ namespace Tendril::Devices {
     std::unique_ptr<BinaryOutputPin> enablePin;
     std::unique_ptr<BinaryOutputPin> clearPin;
 
+    const unsigned int totalPins;
     std::vector<bool> state;
     std::set<unsigned int> allocatedPins;
   };

--- a/libtendril/src/devices/CMakeLists.txt
+++ b/libtendril/src/devices/CMakeLists.txt
@@ -4,5 +4,6 @@ list(APPEND srcs pca9685.cpp)
 list(APPEND srcs pca9685channel.cpp)
 
 list(APPEND srcs directdrivesn74x595.cpp)
+list(APPEND srcs boparray595.cpp)
 
 target_sources(tendril PRIVATE ${srcs})

--- a/libtendril/src/devices/CMakeLists.txt
+++ b/libtendril/src/devices/CMakeLists.txt
@@ -3,4 +3,6 @@ set(srcs)
 list(APPEND srcs pca9685.cpp)
 list(APPEND srcs pca9685channel.cpp)
 
+list(APPEND srcs directdrivesn74x595.cpp)
+
 target_sources(tendril PRIVATE ${srcs})

--- a/libtendril/src/devices/boparray595.cpp
+++ b/libtendril/src/devices/boparray595.cpp
@@ -1,4 +1,5 @@
 #include <map>
+#include <iostream>
 
 #include "tendril/devices/directdrivesn74x595.hpp"
 #include "tendril/devices/boparray595.hpp"

--- a/libtendril/src/devices/boparray595.cpp
+++ b/libtendril/src/devices/boparray595.cpp
@@ -1,0 +1,26 @@
+#include <map>
+
+#include "tendril/devices/directdrivesn74x595.hpp"
+#include "tendril/devices/boparray595.hpp"
+
+namespace Tendril::Devices {
+  BOPArray595::BOPArray595(std::shared_ptr<DirectDriveSN74x595> controller,
+			   std::vector<unsigned int> pins)
+    : BOPArray(pins.size()),
+      controller(controller),
+      pinMapping(pins) {}
+
+  void BOPArray595::Update() {
+    std::map<unsigned int, bool> updates;
+    
+    // Build up list of pins to update on the chip
+    for( size_t i=0; i<this->pinState.size(); ++i ) {
+      unsigned int pinOnChip = this->pinMapping.at(i);
+      bool desiredState = this->pinState.at(i);
+      updates[pinOnChip] = desiredState;
+    }
+
+    //! Send the request
+    this->controller->SetPinsAndSend(updates);
+  }
+}

--- a/libtendril/src/devices/directdrivesn74x595.cpp
+++ b/libtendril/src/devices/directdrivesn74x595.cpp
@@ -17,13 +17,13 @@ namespace Tendril::Devices {
     : Device(deviceName),
       HardwareProvider(),
       levelDelay(DirectDriveSN74x595::DefaultLevelDelay),
+      totalPins(chainLength * DirectDriveSN74x595::PinsPerChip),
       updateMutex(),
       clockPin(std::move(clock)),
       dataPin(std::move(data)),
       latchPin(std::move(latch)),
       enablePin(std::move(enable)),
       clearPin(std::move(clear)),
-      totalPins(chainLength * DirectDriveSN74x595::PinsPerChip),
       state(),
       allocatedPins() {
     if( this->clearPin ) {

--- a/libtendril/src/devices/directdrivesn74x595.cpp
+++ b/libtendril/src/devices/directdrivesn74x595.cpp
@@ -1,0 +1,23 @@
+#include "tendril/devices/directdrivesn74x595.hpp"
+
+namespace Tendril::Devices {
+  void
+  DirectDriveSN74x595::Register(HardwareManager& hwManager) {
+    // Get a shared pointer and navigate around the types
+    auto ptr = this->shared_from_this();
+    auto ptr595 = std::dynamic_pointer_cast<DirectDriveSN74x595>(ptr);
+    hwManager.bopArrayProviderRegistrar.Register(this->name,
+						 ptr595);
+
+  }
+
+  void
+  DirectDriveSN74x595::EnableOutputs(bool enable) {
+    if( this->enablePin ) {
+      // Recall that it's an active low enable
+      this->enablePin->Set(!enable);
+    } else {
+      throw std::logic_error("Enable pin is not set for 74x595");
+    }
+  }
+}

--- a/libtendril/src/devices/directdrivesn74x595.cpp
+++ b/libtendril/src/devices/directdrivesn74x595.cpp
@@ -1,3 +1,5 @@
+#include <thread>
+
 #include "tendril/devices/directdrivesn74x595.hpp"
 
 namespace Tendril::Devices {
@@ -19,5 +21,53 @@ namespace Tendril::Devices {
     } else {
       throw std::logic_error("Enable pin is not set for 74x595");
     }
+  }
+
+  void
+  DirectDriveSN74x595::Reset() {
+    std::lock_guard<std::mutex> lck(this->updateMutex);
+
+    if( this->clearPin ) {
+      // The 'Clear' is active low
+      this->clearPin->Set(false);
+      std::this_thread::sleep_for(this->levelDelay);
+      this->clearPin->Set(true);
+    } else {
+      throw std::logic_error("Reset pin is not set for 74x595");
+    }
+  }
+
+  void
+  DirectDriveSN74x595::SetPinsAndSend(const std::map<unsigned int,bool>& pinUpdates) {
+    std::lock_guard<std::mutex> lck(this->updateMutex);
+    
+    // Update the state vector
+    for( auto it : pinUpdates ) {
+      if( this->allocatedPins.count(it.first) != 1 ) {
+	throw std::logic_error("SetPinsAndSend pin not allocated");
+      }
+
+      this->state.at(it.first) = it.second;
+    }
+
+    // Make sure the clock pin and latch pins are low
+    this->clockPin->Set(false);
+    this->latchPin->Set(false);
+    
+    // Reverse iterate to send the values
+    for( auto rit=this->state.rbegin(); rit!=this->state.rend(); ++rit ) {
+      this->dataPin->Set(*rit);
+      std::this_thread::sleep_for(this->levelDelay);
+
+      // Clock the value in
+      this->clockPin->Set(true);
+      std::this_thread::sleep_for(this->levelDelay);
+      this->clockPin->Set(false);
+    }
+
+    // Transfer the data to the output registers
+    this->latchPin->Set(true);
+    std::this_thread::sleep_for(this->levelDelay);
+    this->latchPin->Set(false);
   }
 }

--- a/libtendril/src/devices/directdrivesn74x595.cpp
+++ b/libtendril/src/devices/directdrivesn74x595.cpp
@@ -3,6 +3,35 @@
 #include "tendril/devices/directdrivesn74x595.hpp"
 
 namespace Tendril::Devices {
+  DirectDriveSN74x595::DirectDriveSN74x595(const std::string deviceName,
+					   const unsigned int chainLength,
+					   std::unique_ptr<BinaryOutputPin>& clock,
+					   std::unique_ptr<BinaryOutputPin>& data,
+					   std::unique_ptr<BinaryOutputPin>& latch,
+					   std::unique_ptr<BinaryOutputPin>& enable,
+					   std::unique_ptr<BinaryOutputPin>& clear )
+    : Device(deviceName),
+      HardwareProvider(),
+      levelDelay(DirectDriveSN74x595::DefaultLevelDelay),
+      updateMutex(),
+      clockPin(std::move(clock)),
+      dataPin(std::move(data)),
+      latchPin(std::move(latch)),
+      enablePin(std::move(enable)),
+      clearPin(std::move(clear)),
+      totalPins(chainLength * DirectDriveSN74x595::PinsPerChip),
+      state(),
+      allocatedPins() {
+    if( this->clearPin ) {
+      this->Reset();
+    }
+    if( chainLength == 0 ) {
+      throw std::logic_error("Invalid chain length for 595");
+    }
+    this->state.reserve(chainLength * this->PinsPerChip);
+  }
+					   
+  
   void
   DirectDriveSN74x595::Register(HardwareManager& hwManager) {
     // Get a shared pointer and navigate around the types

--- a/libtendril/src/devices/directdrivesn74x595.cpp
+++ b/libtendril/src/devices/directdrivesn74x595.cpp
@@ -32,7 +32,7 @@ namespace Tendril::Devices {
     if( chainLength == 0 ) {
       throw std::logic_error("Invalid chain length for 595");
     }
-    this->state.reserve(chainLength * this->PinsPerChip);
+    this->state.resize(chainLength * this->PinsPerChip);
   }
 					   
   

--- a/libtendril/test/CMakeLists.txt
+++ b/libtendril/test/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND srcs utilitiestests.cpp)
 
 
 list(APPEND srcs pca9685tests.cpp)
+list(APPEND srcs directdrivesn74x595tests.cpp)
 
 add_executable(TendrilTest ${srcs})
 target_link_libraries(TendrilTest PUBLIC tendril Boost::boost)

--- a/libtendril/test/directdrivesn74x595tests.cpp
+++ b/libtendril/test/directdrivesn74x595tests.cpp
@@ -52,4 +52,48 @@ BOOST_AUTO_TEST_CASE(Smoke)
   bopArray->Update();
 }
 
+BOOST_AUTO_TEST_CASE(SmokeNoEnableClear)
+{
+   const std::string name = "My595";
+  const unsigned int chips = 2;
+  std::unique_ptr<Tendril::BinaryOutputPin> clkPin = std::make_unique<Tendril::Mocks::MockBOP>();
+  std::unique_ptr<Tendril::BinaryOutputPin> datPin = std::make_unique<Tendril::Mocks::MockBOP>();
+  std::unique_ptr<Tendril::BinaryOutputPin> lthPin = std::make_unique<Tendril::Mocks::MockBOP>();
+  std::unique_ptr<Tendril::BinaryOutputPin> enbPin;
+  std::unique_ptr<Tendril::BinaryOutputPin> clrPin;
+
+  
+  auto sn595 = std::make_shared<Tendril::Devices::DirectDriveSN74x595>(name,
+								       chips,
+								       clkPin,
+								       datPin,
+								       lthPin,
+								       enbPin,
+								       clrPin);
+  BOOST_REQUIRE(sn595);
+
+  // Don't have the enable and clear pins, so expect some exceptions
+  BOOST_CHECK_THROW( sn595->Reset(), std::logic_error );
+  BOOST_CHECK_THROW( sn595->EnableOutputs(false), std::logic_error );
+  
+
+  // Try getting a BOPArray
+  const std::string arrayId = "SomeArray";
+  Tendril::SettingsMap arraySettings;
+  arraySettings["0"] = "15";
+  arraySettings["1"] = "2";
+  arraySettings["2"] = "5";
+
+  auto bopArray = sn595->GetHardware(arrayId, arraySettings);
+  BOOST_REQUIRE( bopArray );
+  auto boparray595 = dynamic_cast<Tendril::Devices::BOPArray595*>(bopArray.get());
+  BOOST_REQUIRE( boparray595 );
+
+  // Set something, and make sure that it at least doesn't throw any exceptions
+  bopArray->Set(0, true);
+  bopArray->Set(1, false);
+  bopArray->Set(2, true);
+  bopArray->Update();
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/libtendril/test/directdrivesn74x595tests.cpp
+++ b/libtendril/test/directdrivesn74x595tests.cpp
@@ -1,0 +1,51 @@
+#include <boost/test/unit_test.hpp>
+
+#include "tendril/mocks/mockbop.hpp"
+
+#include "tendril/devices/directdrivesn74x595.hpp"
+#include "tendril/devices/boparray595.hpp"
+
+BOOST_AUTO_TEST_SUITE(DirectDriveSN74x595)
+
+BOOST_AUTO_TEST_CASE(Smoke)
+{
+  const std::string name = "My595";
+  const unsigned int chips = 1;
+  std::unique_ptr<Tendril::BinaryOutputPin> clkPin = std::make_unique<Tendril::Mocks::MockBOP>();
+  std::unique_ptr<Tendril::BinaryOutputPin> datPin = std::make_unique<Tendril::Mocks::MockBOP>();
+  std::unique_ptr<Tendril::BinaryOutputPin> lthPin = std::make_unique<Tendril::Mocks::MockBOP>();
+  std::unique_ptr<Tendril::BinaryOutputPin> enbPin = std::make_unique<Tendril::Mocks::MockBOP>();
+  std::unique_ptr<Tendril::BinaryOutputPin> clrPin = std::make_unique<Tendril::Mocks::MockBOP>();
+
+  auto clrPtr = dynamic_cast<Tendril::Mocks::MockBOP*>(clrPin.get());
+  BOOST_REQUIRE( clrPtr );
+  
+  auto sn595 = std::make_shared<Tendril::Devices::DirectDriveSN74x595>(name,
+								       chips,
+								       clkPin,
+								       datPin,
+								       lthPin,
+								       enbPin,
+								       clrPin);
+  BOOST_REQUIRE(sn595);
+  // Check the clear pin was set high
+  BOOST_CHECK_EQUAL( clrPtr->lastLevel, true );
+
+  // Try getting a BOPArray
+  const std::string arrayId = "SomeArray";
+  Tendril::SettingsMap arraySettings;
+  arraySettings["0"] = "7";
+  arraySettings["1"] = "2";
+
+  auto bopArray = sn595->GetHardware(arrayId, arraySettings);
+  BOOST_REQUIRE( bopArray );
+  auto boparray595 = dynamic_cast<Tendril::Devices::BOPArray595*>(bopArray.get());
+  BOOST_REQUIRE( boparray595 );
+
+  // Set something, and make sure that it at least doesn't throw any exceptions
+  bopArray->Set(0, true);
+  bopArray->Set(1, false);
+  bopArray->Update();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libtendril/test/directdrivesn74x595tests.cpp
+++ b/libtendril/test/directdrivesn74x595tests.cpp
@@ -31,6 +31,10 @@ BOOST_AUTO_TEST_CASE(Smoke)
   // Check the clear pin was set high
   BOOST_CHECK_EQUAL( clrPtr->lastLevel, true );
 
+  // Check that two of the functions work
+  sn595->Reset();
+  sn595->EnableOutputs(true);
+
   // Try getting a BOPArray
   const std::string arrayId = "SomeArray";
   Tendril::SettingsMap arraySettings;


### PR DESCRIPTION
Putting together a class to control an SN74x595 shift register (or chain thereof) which is directly controlled through GPIO pins (as opposed to using SPI). There is a small program `dd595` in the `libpigpiodpp/apps` directory which allows for testing with actual hardware.

This is not yet available from `liblineside` since I have realised that `DeviceRequestData` is going to need to live inside Tendril in order for the requests for pins to be made cleanly. That is more refactoring that I want for this changeset. Beyond that, this is very much an initial implementation. The abstractions are almost certainly not in the right places, and will have to be changed as other devices (or even just an SPI version of the SN74x595) are added.