### PR TITLE
Add testing for enum parsing failures

### DIFF
--- a/liblineside/src/signalflash.cpp
+++ b/liblineside/src/signalflash.cpp
@@ -52,7 +52,7 @@ namespace Lineside {
       std::stringstream msg;
       msg << "Could not parse '";
       msg << src;
-      msg << "' to SignalState";
+      msg << "' to SignalFlash";
       throw std::invalid_argument(msg.str());
     }
   }

--- a/liblineside/test/signalaspecttests.cpp
+++ b/liblineside/test/signalaspecttests.cpp
@@ -34,6 +34,20 @@ BOOST_DATA_TEST_CASE( Parse, nameToAspectZip, name, aspect )
   BOOST_CHECK_EQUAL( aspect, Lineside::Parse<Lineside::SignalAspect>(name) );
 }
 
+BOOST_AUTO_TEST_CASE( BadParse )
+{
+  const std::string badString = "SomeRandomString";
+
+  const std::string expected = "Could not parse 'SomeRandomString' to SignalAspect";
+  BOOST_CHECK_EXCEPTION( Lineside::Parse<Lineside::SignalAspect>(badString),
+			 std::invalid_argument,
+			 [=](const std::invalid_argument& ia) {
+			   BOOST_CHECK_EQUAL( expected, ia.what() );
+			   return expected == ia.what();
+			 });
+}
+
+
 BOOST_DATA_TEST_CASE( TryParse, nameToAspectZip, name, aspect )
 {
   Lineside::SignalAspect result;

--- a/liblineside/test/signalflashtests.cpp
+++ b/liblineside/test/signalflashtests.cpp
@@ -32,4 +32,17 @@ BOOST_DATA_TEST_CASE( Parse, nameToFlashZip, name, flash )
   BOOST_CHECK_EQUAL( flash, Lineside::Parse<Lineside::SignalFlash>(name) );
 }
 
+BOOST_AUTO_TEST_CASE( BadParse )
+{
+  const std::string badString = "SomeRandomString";
+
+  const std::string expected = "Could not parse 'SomeRandomString' to SignalFlash";
+  BOOST_CHECK_EXCEPTION( Lineside::Parse<Lineside::SignalFlash>(badString),
+			 std::invalid_argument,
+			 [=](const std::invalid_argument& ia) {
+			   BOOST_CHECK_EQUAL( expected, ia.what() );
+			   return expected == ia.what();
+			 });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/liblineside/test/signalstatetests.cpp
+++ b/liblineside/test/signalstatetests.cpp
@@ -35,4 +35,17 @@ BOOST_DATA_TEST_CASE( Parse, nameToStateZip, name, state )
   BOOST_CHECK_EQUAL( state, Lineside::Parse<Lineside::SignalState>(name) );
 }
 
+BOOST_AUTO_TEST_CASE( BadParse )
+{
+  const std::string badString = "SomeRandomString";
+
+  const std::string expected = "Could not parse 'SomeRandomString' to SignalState";
+  BOOST_CHECK_EXCEPTION( Lineside::Parse<Lineside::SignalState>(badString),
+			 std::invalid_argument,
+			 [=](const std::invalid_argument& ia) {
+			   BOOST_CHECK_EQUAL( expected, ia.what() );
+			   return expected == ia.what();
+			 });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/liblineside/test/trackcircuitsensortests.cpp
+++ b/liblineside/test/trackcircuitsensortests.cpp
@@ -34,4 +34,17 @@ BOOST_DATA_TEST_CASE( Parse, nameToSensorZip, name, sensor )
   BOOST_CHECK_EQUAL( sensor, Lineside::Parse<Lineside::TrackCircuitSensor>(name) );
 }
 
+BOOST_AUTO_TEST_CASE( BadParse )
+{
+  const std::string badString = "SomeRandomString";
+
+  const std::string expected = "Could not parse 'SomeRandomString' to TrackCircuitSensor";
+  BOOST_CHECK_EXCEPTION( Lineside::Parse<Lineside::TrackCircuitSensor>(badString),
+			 std::invalid_argument,
+			 [=](const std::invalid_argument& ia) {
+			   BOOST_CHECK_EQUAL( expected, ia.what() );
+			   return expected == ia.what();
+			 });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/liblineside/test/turnoutstatetests.cpp
+++ b/liblineside/test/turnoutstatetests.cpp
@@ -43,4 +43,17 @@ BOOST_AUTO_TEST_CASE( Parse )
   BOOST_CHECK_EQUAL( curved, Lineside::TurnoutState::Curved );
 }
 
+BOOST_AUTO_TEST_CASE( BadParse )
+{
+  const std::string badString = "SomeRandomString";
+
+  const std::string expected = "Could not parse 'SomeRandomString' to TurnoutState";
+  BOOST_CHECK_EXCEPTION( Lineside::Parse<Lineside::TurnoutState>(badString),
+			 std::invalid_argument,
+			 [=](const std::invalid_argument& ia) {
+			   BOOST_CHECK_EQUAL( expected, ia.what() );
+			   return expected == ia.what();
+			 });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/libpigpiodpp/test/gpiopulltests.cpp
+++ b/libpigpiodpp/test/gpiopulltests.cpp
@@ -52,4 +52,17 @@ BOOST_DATA_TEST_CASE( Parse, nameToPullZip, name, pull )
   BOOST_CHECK_EQUAL( pull, PiGPIOdpp::Parse<PiGPIOdpp::GPIOPull>(name) );
 }
 
+BOOST_AUTO_TEST_CASE( BadParse )
+{
+  const std::string badString = "SomeRandomString";
+
+  const std::string expected = "Could not parse 'SomeRandomString' to GPIOPull";
+  BOOST_CHECK_EXCEPTION( PiGPIOdpp::Parse<PiGPIOdpp::GPIOPull>(badString),
+			 std::invalid_argument,
+			 [=](const std::invalid_argument& ia) {
+			   BOOST_CHECK_EQUAL( expected, ia.what() );
+			   return expected == ia.what();
+			 });
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The 'failure' side of the `Parse`  routines for the various enumeration classes didn't have any tests, so add some. This turned up an incorrect error message.