### PR TITLE
Add directly driven 74x164 Shift Register

### DIFF
--- a/libtendril/include/tendril/devices/boparray164.hpp
+++ b/libtendril/include/tendril/devices/boparray164.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "tendril/boparray.hpp"
+
+namespace Tendril::Devices {
+  class DirectDriveSN74x164;
+
+  //! A BOPArray controlled by an SN74x164 shift register
+  class BOPArray164 : public BOPArray {
+  public:
+    //! Create an instance
+    BOPArray164(std::shared_ptr<DirectDriveSN74x164> controller,
+                std::vector<unsigned int> pins);
+
+    virtual void Update() override;
+  private:
+    std::shared_ptr<DirectDriveSN74x164> controller;
+    std::vector<unsigned int> pinMapping;
+  };
+}

--- a/libtendril/include/tendril/devices/directdrivesn74x164.hpp
+++ b/libtendril/include/tendril/devices/directdrivesn74x164.hpp
@@ -17,6 +17,7 @@ namespace Tendril::Devices {
   //! Class to represent directly driven chained SN74x164 shift registers
   class DirectDriveSN74x164 : public Device,
 			      public HardwareProvider<BOPArray> {
+  public:
     const std::chrono::microseconds DefaultLevelDelay = std::chrono::microseconds(10);
     const unsigned int PinsPerChip = 8;
 

--- a/libtendril/include/tendril/devices/directdrivesn74x164.hpp
+++ b/libtendril/include/tendril/devices/directdrivesn74x164.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#pragma once
+
+#include <mutex>
+#include <chrono>
+#include <set>
+#include <vector>
+
+#include "tendril/binaryoutputpin.hpp"
+#include "tendril/boparray.hpp"
+#include "tendril/hardwareprovider.hpp"
+
+#include "tendril/devices/device.hpp"
+
+namespace Tendril::Devices {
+  //! Class to represent directly driven chained SN74x164 shift registers
+  class DirectDriveSN74x164 : public Device,
+			      public HardwareProvider<BOPArray> {
+    const std::chrono::microseconds DefaultLevelDelay = std::chrono::microseconds(10);
+    const unsigned int PinsPerChip = 8;
+
+    DirectDriveSN74x164(const std::string deviceName,
+			const unsigned int chainLength,
+			std::unique_ptr<BinaryOutputPin>& clock,
+			std::unique_ptr<BinaryOutputPin>& data,
+			std::unique_ptr<BinaryOutputPin>& clear);
+
+    //! Register with the HardwareManager
+    virtual void Register(HardwareManager& hwManager) override;
+
+    //! Fetch a BOPArray
+    virtual std::unique_ptr<BOPArray>
+    GetHardware(const std::string& hardwareId,
+		const SettingsMap& settings) override;
+    
+    void Reset();
+    
+    void SetPinsAndSend(const std::map<unsigned int,bool>& pinUpdates);
+    
+    //! Delay to allow output pin level to stabilise
+    /*!
+      This is the delay between pin updates. For example,
+      this is the delay imposed between the dataPin level being set
+      and the clockPin being set to high. The clockPin will
+      also then remain high for at least this long.
+      
+      Since this is passed to sleep() the exact wait is
+      imprecise.
+    */
+    std::chrono::microseconds levelDelay;
+    
+    //! Total number of pins available for use
+    const unsigned int totalPins;
+  private:
+    std::mutex updateMutex;
+
+    std::unique_ptr<BinaryOutputPin> clockPin;
+    std::unique_ptr<BinaryOutputPin> dataPin;
+    std::unique_ptr<BinaryOutputPin> clearPin;
+    
+    std::vector<bool> state;
+    std::set<unsigned int> allocatedPins;
+  };
+}

--- a/libtendril/include/tendril/devices/directdrivesn74x164data.hpp
+++ b/libtendril/include/tendril/devices/directdrivesn74x164data.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "tendril/devices/devicedata.hpp"
+#include "tendril/hardwarerequestdata.hpp"
+
+namespace Tendril::Devices {
+  class DirectDriveSN74x164Data : public DeviceData {
+  public:
+    const std::string chainLengthSetting = "chainLength";
+    
+    DirectDriveSN74x164Data()
+      : DeviceData(),
+	clockPin(),
+	dataPin(),
+	clearPin() {}
+    
+    void ConstructAndRegister(HardwareManager& hw) override;
+    
+    HardwareRequestData clockPin;
+    HardwareRequestData dataPin;
+    HardwareRequestData clearPin;
+  };
+}

--- a/libtendril/src/devices/CMakeLists.txt
+++ b/libtendril/src/devices/CMakeLists.txt
@@ -8,5 +8,6 @@ list(APPEND srcs directdrivesn74x595.cpp)
 list(APPEND srcs boparray595.cpp)
 
 list(APPEND srcs directdrivesn74x164.cpp)
+list(APPEND srcs boparray164.cpp)
 
 target_sources(tendril PRIVATE ${srcs})

--- a/libtendril/src/devices/CMakeLists.txt
+++ b/libtendril/src/devices/CMakeLists.txt
@@ -7,6 +7,7 @@ list(APPEND srcs directdrivesn74x595data.cpp)
 list(APPEND srcs directdrivesn74x595.cpp)
 list(APPEND srcs boparray595.cpp)
 
+list(APPEND srcs directdrivesn74x164data.cpp)
 list(APPEND srcs directdrivesn74x164.cpp)
 list(APPEND srcs boparray164.cpp)
 

--- a/libtendril/src/devices/CMakeLists.txt
+++ b/libtendril/src/devices/CMakeLists.txt
@@ -7,4 +7,6 @@ list(APPEND srcs directdrivesn74x595data.cpp)
 list(APPEND srcs directdrivesn74x595.cpp)
 list(APPEND srcs boparray595.cpp)
 
+list(APPEND srcs directdrivesn74x164.cpp)
+
 target_sources(tendril PRIVATE ${srcs})

--- a/libtendril/src/devices/boparray164.cpp
+++ b/libtendril/src/devices/boparray164.cpp
@@ -1,0 +1,27 @@
+#include <map>
+#include <iostream>
+
+#include "tendril/devices/directdrivesn74x164.hpp"
+#include "tendril/devices/boparray164.hpp"
+
+namespace Tendril::Devices {
+  BOPArray164::BOPArray164(std::shared_ptr<DirectDriveSN74x164> controller,
+			   std::vector<unsigned int> pins)
+    : BOPArray(pins.size()),
+      controller(controller),
+      pinMapping(pins) {}
+
+  void BOPArray164::Update() {
+    std::map<unsigned int, bool> updates;
+    
+    // Build up list of pins to update on the chip
+    for( size_t i=0; i<this->pinState.size(); ++i ) {
+      unsigned int pinOnChip = this->pinMapping.at(i);
+      bool desiredState = this->pinState.at(i);
+      updates[pinOnChip] = desiredState;
+    }
+
+    //! Send the request
+    this->controller->SetPinsAndSend(updates);
+  }
+}

--- a/libtendril/src/devices/directdrivesn74x164.cpp
+++ b/libtendril/src/devices/directdrivesn74x164.cpp
@@ -26,9 +26,64 @@ namespace Tendril::Devices {
       this->Reset();
     }
     if( chainLength == 0 ) {
-      throw std::logic_error("Invalid chain length for 595");
+      throw std::logic_error("Invalid chain length for 164");
     }
     this->state.resize(chainLength * this->PinsPerChip);
+  }
+
+    
+  void
+  DirectDriveSN74x164::Register(HardwareManager& hwManager) {
+    // Get a shared pointer and navigate around the types
+    auto ptr = this->shared_from_this();
+    auto ptr164 = std::dynamic_pointer_cast<DirectDriveSN74x164>(ptr);
+    hwManager.bopArrayProviderRegistrar.Register(this->name,
+						 ptr164);
+
+  }
+
+  
+  void
+  DirectDriveSN74x164::Reset() {
+    std::lock_guard<std::mutex> lck(this->updateMutex);
+    
+    if( this->clearPin ) {
+      // The 'Clear' is active low
+      this->clearPin->Set(false);
+      std::this_thread::sleep_for(this->levelDelay);
+      this->clearPin->Set(true);
+    } else {
+      throw std::logic_error("Reset pin is not set for 74x164");
+    }
+  }
+
+
+  void
+  DirectDriveSN74x164::SetPinsAndSend(const std::map<unsigned int,bool>& pinUpdates) {
+    std::lock_guard<std::mutex> lck(this->updateMutex);
+    
+    // Update the state vector
+    for( auto it : pinUpdates ) {
+      if( this->allocatedPins.count(it.first) != 1 ) {
+	throw std::logic_error("SetPinsAndSend pin not allocated");
+      }
+      
+      this->state.at(it.first) = it.second;
+    }
+    
+    // Make sure the clock pin and latch pins are low
+    this->clockPin->Set(false);
+    
+    // Reverse iterate to send the values
+    for( auto rit=this->state.rbegin(); rit!=this->state.rend(); ++rit ) {
+      this->dataPin->Set(*rit);
+      std::this_thread::sleep_for(this->levelDelay);
+      
+      // Clock the value in
+      this->clockPin->Set(true);
+      std::this_thread::sleep_for(this->levelDelay);
+      this->clockPin->Set(false);
+    }
   }
   
 }

--- a/libtendril/src/devices/directdrivesn74x164.cpp
+++ b/libtendril/src/devices/directdrivesn74x164.cpp
@@ -4,6 +4,7 @@
 #include "tendril/keyexception.hpp"
 
 
+#include "tendril/devices/boparray164.hpp"
 #include "tendril/devices/directdrivesn74x164.hpp"
 
 namespace Tendril::Devices {
@@ -42,6 +43,36 @@ namespace Tendril::Devices {
 
   }
 
+
+  std::unique_ptr<BOPArray>
+  DirectDriveSN74x164::GetHardware(const std::string& hardwareId,
+				   const SettingsMap& settings) {
+    // Convert the settings to an ordered list of strings
+    auto pinStringList = BOPArray::ExtractPinList(settings);
+    std::vector<unsigned int> pinList;
+    for(auto s : pinStringList) {
+      unsigned int nxt = std::stoul(s);
+      pinList.push_back(nxt);
+    }
+
+    // Update the list of pins already given out
+    for( unsigned int p : pinList ) {
+      if( allocatedPins.count(p) != 0 ) {
+	throw DuplicateKeyException(std::to_string(p));
+      }
+      if( p >= this->totalPins ) {
+	std::stringstream msg;
+	msg << "Pin " << p << " too large for " << hardwareId;
+	throw std::logic_error(msg.str());
+      }
+      this->allocatedPins.insert(p);
+    }
+    
+    auto myself = std::dynamic_pointer_cast<DirectDriveSN74x164>(this->shared_from_this());
+    auto result = std::make_unique<BOPArray164>(myself, pinList);
+
+    return result;
+  }
   
   void
   DirectDriveSN74x164::Reset() {

--- a/libtendril/src/devices/directdrivesn74x164.cpp
+++ b/libtendril/src/devices/directdrivesn74x164.cpp
@@ -1,0 +1,34 @@
+#include <thread>
+#include <sstream>
+
+#include "tendril/keyexception.hpp"
+
+
+#include "tendril/devices/directdrivesn74x164.hpp"
+
+namespace Tendril::Devices {
+  DirectDriveSN74x164::DirectDriveSN74x164(const std::string deviceName,
+					   const unsigned int chainLength,
+					   std::unique_ptr<BinaryOutputPin>& clock,
+					   std::unique_ptr<BinaryOutputPin>& data,
+					   std::unique_ptr<BinaryOutputPin>& clear)
+    : Device(deviceName),
+      HardwareProvider(),
+      levelDelay(DirectDriveSN74x164::DefaultLevelDelay),
+      totalPins(chainLength * DirectDriveSN74x164::PinsPerChip),
+      updateMutex(),
+      clockPin(std::move(clock)),
+      dataPin(std::move(data)),
+      clearPin(std::move(clear)),
+      state(),
+      allocatedPins() {
+    if( this->clearPin ) {
+      this->Reset();
+    }
+    if( chainLength == 0 ) {
+      throw std::logic_error("Invalid chain length for 595");
+    }
+    this->state.resize(chainLength * this->PinsPerChip);
+  }
+  
+}

--- a/libtendril/src/devices/directdrivesn74x164data.cpp
+++ b/libtendril/src/devices/directdrivesn74x164data.cpp
@@ -1,0 +1,35 @@
+#include "tendril/devices/directdrivesn74x164.hpp"
+
+#include "tendril/devices/directdrivesn74x164data.hpp"
+
+namespace Tendril::Devices {
+  void
+  DirectDriveSN74x164Data::ConstructAndRegister(HardwareManager& hw) {
+    // Get the pins
+    auto clock = hw.GetBOP(this->clockPin);
+    auto data = hw.GetBOP(this->dataPin);
+
+    std::unique_ptr<BinaryOutputPin> clear;
+    if( this->clearPin.providerName != Tendril::Devices::NotConnected ) {
+      clear = hw.GetBOP(this->clearPin);
+    }
+
+    // Get the number of devices in the chain
+    if( this->settings.size() != 1 ) {
+      throw std::logic_error("DD164 should only have chainLength as a setting");
+    }
+
+    if( this->settings.count(this->chainLengthSetting) != 1 ) {
+      throw KeyNotFoundException(this->chainLengthSetting);
+    }
+    std::string clString = this->settings.at(this->chainLengthSetting);
+    unsigned int chainLength = std::stoul(clString);
+
+    auto dd164 = std::make_shared<DirectDriveSN74x164>(this->name,
+						       chainLength,
+						       clock,
+						       data,
+						       clear);
+    dd164->Register(hw);
+  }
+}

--- a/libtendril/test/devices/CMakeLists.txt
+++ b/libtendril/test/devices/CMakeLists.txt
@@ -7,6 +7,7 @@ list(APPEND srcs pca9685tests.cpp)
 list(APPEND srcs directdrivesn74x595datatests.cpp)
 list(APPEND srcs directdrivesn74x595tests.cpp)
 
+list(APPEND srcs directdrivesn74x164datatests.cpp)
 list(APPEND srcs directdrivesn74x164tests.cpp)
 
 target_sources(TendrilTest PRIVATE ${srcs})

--- a/libtendril/test/devices/CMakeLists.txt
+++ b/libtendril/test/devices/CMakeLists.txt
@@ -7,4 +7,6 @@ list(APPEND srcs pca9685tests.cpp)
 list(APPEND srcs directdrivesn74x595datatests.cpp)
 list(APPEND srcs directdrivesn74x595tests.cpp)
 
+list(APPEND srcs directdrivesn74x164tests.cpp)
+
 target_sources(TendrilTest PRIVATE ${srcs})

--- a/libtendril/test/devices/directdrivesn74x164datatests.cpp
+++ b/libtendril/test/devices/directdrivesn74x164datatests.cpp
@@ -1,0 +1,54 @@
+#include <boost/test/unit_test.hpp>
+
+#include "tendril/mocks/utilities.hpp"
+#include "tendril/mocks/mockbop.hpp"
+#include "tendril/mocks/mockhardwareprovider.hpp"
+
+#include "tendril/devices/directdrivesn74x164.hpp"
+#include "tendril/devices/directdrivesn74x164data.hpp"
+
+BOOST_AUTO_TEST_SUITE(Devices)
+
+BOOST_AUTO_TEST_SUITE(DirectDriveSN74x164Data)
+
+BOOST_AUTO_TEST_CASE(ConstructAndRegister)
+{
+  auto hw = Tendril::Mocks::GetMockHardwareManager();
+
+  // Set up a basic set of data
+  Tendril::Devices::DirectDriveSN74x164Data target;
+  target.clockPin.providerName = Tendril::Mocks::BOPProviderId;
+  target.clockPin.idOnProvider = "01";
+  target.dataPin.providerName = Tendril::Mocks::BOPProviderId;
+  target.dataPin.idOnProvider = "03";
+  target.clearPin.providerName = Tendril::Devices::NotConnected;
+  target.settings["chainLength"] = "1";
+  const std::string devName = "MySR";
+  target.name = devName;
+
+  BOOST_TEST_CHECKPOINT("Data entered");
+
+  // Create and register the chain
+  target.ConstructAndRegister(*hw);
+
+  // Now check that we can get it
+  auto bapProvider = hw->bopArrayProviderRegistrar.Retrieve(devName);
+  BOOST_REQUIRE(bapProvider);
+  auto dd164 = std::dynamic_pointer_cast<Tendril::Devices::DirectDriveSN74x164>(bapProvider);
+  BOOST_REQUIRE(dd164);
+  
+  // See if the pins were taken
+  auto bopprovider = hw->bopProviderRegistrar.Retrieve(Tendril::Mocks::BOPProviderId);
+  BOOST_REQUIRE(bopprovider);
+  auto mockbopprovider = std::dynamic_pointer_cast<
+    Tendril::Mocks::MockHardwareProvider<Tendril::BinaryOutputPin,Tendril::Mocks::MockBOP>
+    >(bopprovider);
+  BOOST_REQUIRE(mockbopprovider);
+  BOOST_CHECK_EQUAL( mockbopprovider->hardware.size(), 2 );
+  BOOST_CHECK_NO_THROW( mockbopprovider->hardware.at("01") );
+  BOOST_CHECK_NO_THROW( mockbopprovider->hardware.at("03") );
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libtendril/test/devices/directdrivesn74x164tests.cpp
+++ b/libtendril/test/devices/directdrivesn74x164tests.cpp
@@ -2,40 +2,36 @@
 
 #include "tendril/mocks/mockbop.hpp"
 
-#include "tendril/devices/directdrivesn74x595.hpp"
-#include "tendril/devices/boparray595.hpp"
+#include "tendril/devices/directdrivesn74x164.hpp"
+#include "tendril/devices/boparray164.hpp"
 
 BOOST_AUTO_TEST_SUITE(Devices)
 
-BOOST_AUTO_TEST_SUITE(DirectDriveSN74x595)
+BOOST_AUTO_TEST_SUITE(DirectDriveSN74x164)
 
 BOOST_AUTO_TEST_CASE(Smoke)
 {
-  const std::string name = "My595";
+  const std::string name = "My164";
   const unsigned int chips = 1;
   std::unique_ptr<Tendril::BinaryOutputPin> clkPin = std::make_unique<Tendril::Mocks::MockBOP>();
   std::unique_ptr<Tendril::BinaryOutputPin> datPin = std::make_unique<Tendril::Mocks::MockBOP>();
-  std::unique_ptr<Tendril::BinaryOutputPin> lthPin = std::make_unique<Tendril::Mocks::MockBOP>();
-  std::unique_ptr<Tendril::BinaryOutputPin> enbPin = std::make_unique<Tendril::Mocks::MockBOP>();
   std::unique_ptr<Tendril::BinaryOutputPin> clrPin = std::make_unique<Tendril::Mocks::MockBOP>();
 
   auto clrPtr = dynamic_cast<Tendril::Mocks::MockBOP*>(clrPin.get());
   BOOST_REQUIRE( clrPtr );
   
-  auto sn595 = std::make_shared<Tendril::Devices::DirectDriveSN74x595>(name,
+  auto sn164 = std::make_shared<Tendril::Devices::DirectDriveSN74x164>(name,
 								       chips,
 								       clkPin,
 								       datPin,
-								       lthPin,
-								       enbPin,
 								       clrPin);
-  BOOST_REQUIRE(sn595);
+  BOOST_REQUIRE(sn164);
+  
   // Check the clear pin was set high
   BOOST_CHECK_EQUAL( clrPtr->lastLevel, true );
 
   // Check that two of the functions work
-  sn595->Reset();
-  sn595->EnableOutputs(true);
+  sn164->Reset();
 
   // Try getting a BOPArray
   const std::string arrayId = "SomeArray";
@@ -43,10 +39,10 @@ BOOST_AUTO_TEST_CASE(Smoke)
   arraySettings["0"] = "7";
   arraySettings["1"] = "2";
 
-  auto bopArray = sn595->GetHardware(arrayId, arraySettings);
+  auto bopArray = sn164->GetHardware(arrayId, arraySettings);
   BOOST_REQUIRE( bopArray );
-  auto boparray595 = dynamic_cast<Tendril::Devices::BOPArray595*>(bopArray.get());
-  BOOST_REQUIRE( boparray595 );
+  auto boparray164 = dynamic_cast<Tendril::Devices::BOPArray164*>(bopArray.get());
+  BOOST_REQUIRE( boparray164 );
 
   // Set something, and make sure that it at least doesn't throw any exceptions
   bopArray->Set(0, true);
@@ -56,27 +52,22 @@ BOOST_AUTO_TEST_CASE(Smoke)
 
 BOOST_AUTO_TEST_CASE(SmokeNoEnableClear)
 {
-   const std::string name = "My595";
+   const std::string name = "My164";
   const unsigned int chips = 2;
   std::unique_ptr<Tendril::BinaryOutputPin> clkPin = std::make_unique<Tendril::Mocks::MockBOP>();
   std::unique_ptr<Tendril::BinaryOutputPin> datPin = std::make_unique<Tendril::Mocks::MockBOP>();
-  std::unique_ptr<Tendril::BinaryOutputPin> lthPin = std::make_unique<Tendril::Mocks::MockBOP>();
-  std::unique_ptr<Tendril::BinaryOutputPin> enbPin;
   std::unique_ptr<Tendril::BinaryOutputPin> clrPin;
 
   
-  auto sn595 = std::make_shared<Tendril::Devices::DirectDriveSN74x595>(name,
+  auto sn164 = std::make_shared<Tendril::Devices::DirectDriveSN74x164>(name,
 								       chips,
 								       clkPin,
 								       datPin,
-								       lthPin,
-								       enbPin,
 								       clrPin);
-  BOOST_REQUIRE(sn595);
+  BOOST_REQUIRE(sn164);
 
-  // Don't have the enable and clear pins, so expect some exceptions
-  BOOST_CHECK_THROW( sn595->Reset(), std::logic_error );
-  BOOST_CHECK_THROW( sn595->EnableOutputs(false), std::logic_error );
+  // Don't have the clear pin, so expect some exception
+  BOOST_CHECK_THROW( sn164->Reset(), std::logic_error );
   
 
   // Try getting a BOPArray
@@ -86,10 +77,10 @@ BOOST_AUTO_TEST_CASE(SmokeNoEnableClear)
   arraySettings["1"] = "2";
   arraySettings["2"] = "5";
 
-  auto bopArray = sn595->GetHardware(arrayId, arraySettings);
+  auto bopArray = sn164->GetHardware(arrayId, arraySettings);
   BOOST_REQUIRE( bopArray );
-  auto boparray595 = dynamic_cast<Tendril::Devices::BOPArray595*>(bopArray.get());
-  BOOST_REQUIRE( boparray595 );
+  auto boparray164 = dynamic_cast<Tendril::Devices::BOPArray164*>(bopArray.get());
+  BOOST_REQUIRE( boparray164 );
 
   // Set something, and make sure that it at least doesn't throw any exceptions
   bopArray->Set(0, true);


### PR DESCRIPTION
Add a class to `libtendril` which can manage a 74x164 shift register. This is very similar to the 74x595 shift register, and common code should be refactored in future.