### PR TITLE
Install boost manually

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Threads REQUIRED)
 
 # Follow needed on OSX due to DYLD_LIBRARY_PATH issues when running ctest
 # set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost 1.72 REQUIRED
+find_package(Boost 1.71 REQUIRED
   COMPONENTS filesystem program_options)
 
 find_package(Doxygen)

--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -10,7 +10,7 @@ parameters:
 
 steps:
 - bash: |
-    sudo apt install libboost-dev
+    sudo apt install libboost-dev libboost-all-dev
   displayName: "Install boost"
   
 - bash: |

--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -12,9 +12,7 @@ steps:
 - task: Bash@3
   displayName: "Install boost"
   inputs:
-    script: |
-      sudo apt install libboost-dev
-      sudo apt install libboost-all-dev
+    script: sudo apt install libboost-dev
   
 - bash: |
     sudo updatedb

--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -10,6 +10,7 @@ parameters:
 
 steps:
 - bash: |
+    sudo apt-get update
     sudo apt install libboost-dev libboost-all-dev
   displayName: "Install boost"
   

--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -9,6 +9,12 @@ parameters:
   makeTarget: ''
 
 steps:
+- task: Bash@3
+  displayName: "Install boost"
+  script: |
+    sudo apt install libboost-dev
+    sudo apt install libboost-all-dev
+  
 - bash: |
     sudo updatedb
     echo ""

--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -9,10 +9,9 @@ parameters:
   makeTarget: ''
 
 steps:
-- task: Bash@3
+- bash: |
+    sudo apt install libboost-dev
   displayName: "Install boost"
-  inputs:
-    script: sudo apt install libboost-dev
   
 - bash: |
     sudo updatedb

--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -3,7 +3,7 @@
 parameters:
   srcDir: ''
   bldDir: ''
-  cmakeArgs: '-DBoost_DEBUG=ON -DBOOST_ROOT=/opt/hostedtoolcache/boost/1.72.0/x64 -DBoost_ARCHITECTURE=-x64'
+  cmakeArgs: '-DBoost_DEBUG=ON' # -DBOOST_ROOT=/opt/hostedtoolcache/boost/1.72.0/x64 -DBoost_ARCHITECTURE=-x64'
   cmakeExtraArgs: ''
   makeExtraArgs: ''
   makeTarget: ''

--- a/azuredevops/cmake-steps-template.yml
+++ b/azuredevops/cmake-steps-template.yml
@@ -11,9 +11,10 @@ parameters:
 steps:
 - task: Bash@3
   displayName: "Install boost"
-  script: |
-    sudo apt install libboost-dev
-    sudo apt install libboost-all-dev
+  inputs:
+    script: |
+      sudo apt install libboost-dev
+      sudo apt install libboost-all-dev
   
 - bash: |
     sudo updatedb


### PR DESCRIPTION
It appears that ADO is [removing Boost](https://github.com/actions/virtual-environments/issues/2667). Install it manually, which has forced the dropping of another Boost version.