### PR TITLE
Fixes for GCC 10

### DIFF
--- a/liblineside/src/xml/hardwarerequestdatareader.cpp
+++ b/liblineside/src/xml/hardwarerequestdatareader.cpp
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 #include "lineside/xml/utilities.hpp"
 #include "lineside/xml/settingsreader.hpp"
 

--- a/liblineside/src/xml/settingsreader.cpp
+++ b/liblineside/src/xml/settingsreader.cpp
@@ -1,3 +1,4 @@
+#include <stdexcept>
 #include <xercesc/dom/DOMNodeList.hpp>
 
 #include "lineside/xml/utilities.hpp"

--- a/liblineside/src/xml/softwaremanagerdatareader.cpp
+++ b/liblineside/src/xml/softwaremanagerdatareader.cpp
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 #include <xercesc/dom/DOMNodeList.hpp>
 
 #include "lineside/xml/utilities.hpp"


### PR DESCRIPTION
Compiling with GCC-10 reveals some changes in implicit header inclusion. Explicitly bring in required headers.